### PR TITLE
Update course relationships

### DIFF
--- a/app/management/populate_helpers/curriculum.py
+++ b/app/management/populate_helpers/curriculum.py
@@ -32,19 +32,20 @@ def populate_environmental_studies_curriculum(cmd, colleges):
     course_map = {}
 
     # first pass – courses in the main list
-    for _, _, code, title, credits, _ in TEST_ENVIRONMENTAL_STUDIES_CURRICULUM:
-        dept_code, course_num = code[:3], code[3:]  # safe: 6-char rule
+    for _, col_code, code, title, credits, _ in TEST_ENVIRONMENTAL_STUDIES_CURRICULUM:
+        dept_code, course_num = code[:3], code[3:]
         course, created = Course.objects.get_or_create(
             name=dept_code,
             number=course_num,
-            curriculum=curriculum,
+            college=colleges[col_code],
             defaults={"title": title, "credit_hours": credits},
         )
+        course.curricula.add(curriculum)
         course_map[code] = course
         log(cmd, f"    ↳ Course {code} {'created' if created else 'found'}")
 
     # second pass – ensure every prerequisite course exists (create placeholder if not)
-    for _, _, _, _, _, prereqs in TEST_ENVIRONMENTAL_STUDIES_CURRICULUM:
+    for _, col_code, _, _, _, prereqs in TEST_ENVIRONMENTAL_STUDIES_CURRICULUM:
         if not prereqs:
             continue
         for prereq_code in map(str.strip, prereqs.split(";")):  # strip spaces
@@ -53,12 +54,13 @@ def populate_environmental_studies_curriculum(cmd, colleges):
                 placeholder, _ = Course.objects.get_or_create(
                     name=dept_code,
                     number=course_num,
-                    curriculum=curriculum,
+                    college=colleges[col_code],
                     defaults={
                         "title": f"Placeholder for {prereq_code}",
                         "credit_hours": 0,
                     },
                 )
+                placeholder.curricula.add(curriculum)
                 course_map[prereq_code] = placeholder
                 log(cmd, f"    ↳ Placeholder course {prereq_code} created")
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,4 @@
-from .academics import College, Curriculum, Course, Prerequisite
+from .academics import College, Curriculum, Concentration, Course, Prerequisite
 from .registry import (
     Document,
     Registration,
@@ -13,6 +13,7 @@ from .mixins import StatusHistory
 __all__ = [
     "College",
     "Curriculum",
+    "Concentration",
     "Course",
     "Prerequisite",
     "Section",

--- a/app/models/academics.py
+++ b/app/models/academics.py
@@ -73,6 +73,20 @@ class Curriculum(StatusableMixin, models.Model):
         ]
 
 
+class Concentration(models.Model):
+    """Optional major for a curriculum."""
+
+    name = models.CharField(max_length=255)
+    curriculum = models.ForeignKey(
+        Curriculum,
+        on_delete=models.CASCADE,
+        related_name="concentrations",
+    )
+
+    def __str__(self) -> str:  # pragma: no cover
+        return f"{self.name} ({self.curriculum})"
+
+
 # ------------------------------------------------------------------
 # Course and Prerequisite
 # ------------------------------------------------------------------
@@ -86,18 +100,23 @@ class Course(models.Model):
     description: models.TextField = models.TextField(blank=True)
     credit_hours = models.PositiveSmallIntegerField(
         default=CreditChoices.THREE,
-        choices=CreditChoices.choices,  # 1 / 3 / 4 in the admin dropdown
-        validators=[MinValueValidator(1)],  # still accepts any positive value
-    )
-    curriculum = models.ForeignKey(
-        Curriculum, related_name="courses", on_delete=models.PROTECT
+        choices=CreditChoices.choices,
+        validators=[MinValueValidator(1)],
     )
     college = models.ForeignKey(
         "app.College",
-        null=True,
         on_delete=models.PROTECT,
         related_name="courses",
-        editable=False,  # users pick curriculum, not college
+    )
+    curricula = models.ManyToManyField(
+        Curriculum,
+        related_name="courses",
+        blank=True,
+    )
+    concentrations = models.ManyToManyField(
+        "app.Concentration",
+        related_name="courses",
+        blank=True,
     )
     prerequisites: models.ManyToManyField["Course", "Prerequisite"] = (
         models.ManyToManyField(
@@ -115,9 +134,6 @@ class Course(models.Model):
         updating course_code on the fly
         """
         self.code = f"{self.name}{self.number}"
-        # auto-populate college from curriculum
-        if self.curriculum_id:
-            self.college = self.curriculum.college
         super().save(*args, **kwargs)
 
     def __str__(self) -> str:  # pragma: no cover
@@ -127,7 +143,6 @@ class Course(models.Model):
         constraints = [
             models.UniqueConstraint(
                 fields=["code", "college"],
-                condition=models.Q(college__isnull=False),
                 name="uniq_course_code_per_college",
             )
         ]


### PR DESCRIPTION
## Summary
- expand academic models with `Concentration`
- allow `Course` to belong to multiple curricula and concentrations
- keep college ownership explicit
- adapt curriculum populate helper

## Testing
- ❌ `pytest -q` *(failed: command not found)*
- ❌ `pip install -r requirements-dev.txt` *(failed: network or permission issue)*