### PR TITLE
Implement college auto-fill in course form

### DIFF
--- a/app/academics/admin/core.py
+++ b/app/academics/admin/core.py
@@ -21,7 +21,7 @@ class CourseAdmin(ImportExportModelAdmin, GuardedModelAdmin):
     resource_class = CourseResource
     list_display = ("code", "title", "credit_hours", "college")
     list_filter = ("curricula__college", "curricula")
-    autocomplete_fields = ("curricula",)
+    autocomplete_fields = ("curricula", "college")
     inlines = [SectionInline, PrerequisiteInline, RequiresInline]
     list_select_related = ("college",)
 

--- a/app/academics/admin/forms.py
+++ b/app/academics/admin/forms.py
@@ -1,9 +1,12 @@
 # app/academics/admin/forms.py
 from django import forms
 from django.db import transaction
+from django.contrib import admin
+from django.contrib.admin.widgets import AutocompleteSelect
 
-from app.academics.models import Course, Curriculum, CurriculumCourse
+from app.academics.models import Course, Curriculum, CurriculumCourse, College
 from app.shared.enums import CREDIT_NUMBER
+from app.shared.utils import make_course_code
 
 
 class CourseForm(forms.ModelForm):
@@ -29,6 +32,7 @@ class CourseForm(forms.ModelForm):
     # initial values & non-required title
     # ──────────────────────────────────────────────────────────
     def __init__(self, *args, **kwargs):
+        self.admin_site = kwargs.pop("admin_site", admin.site)
         super().__init__(*args, **kwargs)
 
         # pre-select curricula for existing courses
@@ -42,6 +46,27 @@ class CourseForm(forms.ModelForm):
         # make title optional in the *form* even if model says otherwise
         self.fields["title"].required = False
 
+        # prefill college if the course code uniquely maps to one college
+        if not self.instance.pk:
+            name = (self.data.get("name") or "").strip() or self.initial.get("name", "")
+            number = (self.data.get("number") or "").strip() or self.initial.get("number", "")
+            if name and number:
+                code = make_course_code(name, number)
+                colleges = list(
+                    Course.objects.filter(code=code)
+                    .values_list("college_id", flat=True)
+                    .distinct()
+                )
+                if len(colleges) == 1:
+                    self.fields["college"].required = False
+                    self.initial["college"] = colleges[0]
+                    self.fields["college"].initial = colleges[0]
+                elif len(colleges) > 1:
+                    remote_field = Course._meta.get_field("college").remote_field
+                    self.fields["college"].widget = AutocompleteSelect(
+                        remote_field, self.admin_site
+                    )
+
     # ──────────────────────────────────────────────────────────
     # save logic
     # ──────────────────────────────────────────────────────────
@@ -53,6 +78,23 @@ class CourseForm(forms.ModelForm):
         self._pending_curricula = set(self.cleaned_data.get("curricula", []))
         course = super().save(commit=commit)
         return course
+
+    def clean(self):
+        cleaned = super().clean()
+        if (
+            not cleaned.get("college")
+            and cleaned.get("name")
+            and cleaned.get("number")
+        ):
+            code = make_course_code(cleaned["name"], cleaned["number"])
+            colleges = list(
+                Course.objects.filter(code=code)
+                .values_list("college_id", flat=True)
+                .distinct()
+            )
+            if len(colleges) == 1:
+                cleaned["college"] = College.objects.get(pk=colleges[0])
+        return cleaned
 
     @transaction.atomic
     def save_m2m(self):

--- a/tests/test_course_admin.py
+++ b/tests/test_course_admin.py
@@ -1,0 +1,23 @@
+import pytest
+from django.contrib.admin.widgets import AutocompleteSelect
+
+from app.academics.models import College, Course
+from app.academics.admin.forms import CourseForm
+
+@pytest.mark.django_db
+def test_course_form_prefills_single_college():
+    col = College.objects.create(code="ENG", fullname="Engineering")
+    Course.objects.create(name="MAT", number="101", title="Math", college=col)
+    form = CourseForm(data={"name": "MAT", "number": "101", "title": "New"})
+    assert form.is_valid()
+    assert form.cleaned_data["college"] == col
+
+@pytest.mark.django_db
+def test_course_form_autocomplete_multiple_colleges():
+    c1 = College.objects.create(code="ENG", fullname="Engineering")
+    c2 = College.objects.create(code="SCI", fullname="Science")
+    Course.objects.create(name="CSC", number="101", title="Intro", college=c1)
+    Course.objects.create(name="CSC", number="101", title="Other", college=c2)
+    form = CourseForm(data={"name": "CSC", "number": "101", "title": "New"})
+    widget = form.fields["college"].widget
+    assert isinstance(widget, AutocompleteSelect)


### PR DESCRIPTION
## Summary
- set CourseAdmin's `college` field as autocomplete
- prefill the college in CourseForm when a course code belongs to one college
- show an autocomplete widget when multiple colleges exist for the code
- cover the behaviour with a small admin test

## Testing
- `python3.12 -m pytest -q` *(fails: No module named pytest)*