### PR TITLE
Handle instructor and room creation in section import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ db.sqlite3
 static/*
 *.crt
 nginx/*
+codo-tuth-env/


### PR DESCRIPTION
## Summary
- update ignore list for local venv
- create instructor and room entries when importing sections
- clean csv fields before processing

## Testing
- `codo-tuth-env/bin/black app/`
- `codo-tuth-env/bin/flake8 app/`
- `codo-tuth-env/bin/mypy app/`
- `codo-tuth-env/bin/pytest -q`