### PR TITLE
Handle whitespace cells in CSV import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ db.sqlite3
 static/*
 *.crt
 nginx/*
+codo-tuth-env/

--- a/app/shared/management/populate_helpers/sections.py
+++ b/app/shared/management/populate_helpers/sections.py
@@ -70,17 +70,26 @@ def populate_sections_from_csv(cmd, csv_path: Path | str | IO[str]) -> None:
             course = cw.clean(row["course"], row)
             semester = sw.clean(row["semester"], row)
 
-            number_raw = row.get("number") or ""
-            number_int = int(number_raw) if number_raw.strip().isdigit() else None
+            number_raw = (row.get("number") or "").strip()
+            number_int = int(number_raw) if number_raw.isdigit() else None
+
+            instr_raw = (row.get("instructor") or "").strip()
+            instr_id = int(instr_raw) if instr_raw.isdigit() else None
+
+            room_raw = (row.get("room") or "").strip()
+            room_id = int(room_raw) if room_raw.isdigit() else None
+
+            max_raw = (row.get("max_seats") or "").strip()
+            max_seats = int(max_raw) if max_raw.isdigit() else 30
 
             sec, made = Section.objects.get_or_create(
                 course=course,
                 semester=semester,
                 number=number_int,  # None → autoincrement signal
                 defaults={
-                    "instructor_id": row.get("instructor") or None,
-                    "room_id": row.get("room") or None,
-                    "max_seats": int(row.get("max_seats") or 30),
+                    "instructor_id": instr_id,
+                    "room_id": room_id,
+                    "max_seats": max_seats,
                 },
             )
             created += int(made)

--- a/tests/test_populate_sections.py
+++ b/tests/test_populate_sections.py
@@ -1,0 +1,48 @@
+import io
+from types import SimpleNamespace
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from app.spaces.models import Building, Room
+from app.shared.management.populate_helpers.sections import populate_sections_from_csv
+from app.timetable.models import Section
+
+
+class DummyCmd:
+    def __init__(self) -> None:
+        class DummyStyle:
+            def __getattr__(self, name):
+                return lambda msg: msg
+
+        self.style = DummyStyle()
+        self.stdout = io.StringIO()
+
+
+@pytest.mark.django_db
+def test_populate_sections_strip_and_optional_fields():
+    User = get_user_model()
+    User.objects.create(id=2, username="inst")
+    building = Building.objects.create(id=1, short_name="B1")
+    Room.objects.create(id=1, name="101", building=building)
+
+    csv = io.StringIO(
+        """college,course,semester,number,instructor,room,max_seats\n"
+        "COAS,MATH101,24-25_Sem1, 5 , 2 , 1 , 40\n"
+        "COAS,MATH102,24-25_Sem1, , , , \n"
+    )
+
+    cmd = DummyCmd()
+    populate_sections_from_csv(cmd, csv)
+
+    sec1 = Section.objects.get(course__code="MATH101")
+    assert sec1.number == 5
+    assert sec1.instructor_id == 2
+    assert sec1.room_id == 1
+    assert sec1.max_seats == 40
+
+    sec2 = Section.objects.get(course__code="MATH102")
+    assert sec2.number == 1
+    assert sec2.instructor_id is None
+    assert sec2.room_id is None
+    assert sec2.max_seats == 30


### PR DESCRIPTION
## Summary
- sanitize number/instructor/room/max_seats fields when importing Sections from CSV
- add regression test for populate_sections_from_csv
- ignore local virtual environment directory

## Testing
- `black app/` *(fails: command not found)*
- `flake8 app/` *(fails: command not found)*
- `mypy app/` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*