### PR TITLE
Switch Document profile to GenericForeignKey

### DIFF
--- a/app/registry/models/document.py
+++ b/app/registry/models/document.py
@@ -2,15 +2,16 @@ from __future__ import (
     annotations,
 )
 
-from django.contrib.contenttypes.fields import GenericRelation
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
-
-from app.people.models import StudentProfile
 from app.shared.utils import validate_model_status
 
 
 class Document(models.Model):
-    student_profil = models.ForeignKey(StudentProfile, on_delete=models.CASCADE)
+    profile_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    profile_id = models.PositiveIntegerField()
+    profile = GenericForeignKey("profile_type", "profile_id")
     file = models.FileField(upload_to="documents/")
     document_type = models.CharField(max_length=50)
     status_history = GenericRelation(


### PR DESCRIPTION
## Summary
- make `Document` use a GenericForeignKey so it can link to either student or instructor profiles

## Testing
- `black app/`
- `flake8 app/` *(fails: command not found)*
- `mypy app/` *(fails: plugin not found)*
