### PR TITLE
Move CourseWidget to academics widgets module

### DIFF
--- a/app/academics/admin/widgets.py
+++ b/app/academics/admin/widgets.py
@@ -1,0 +1,27 @@
+from import_export import widgets
+from app.academics.models.college import College
+from app.academics.models.course import Course
+from app.shared.management.populate_helpers.curriculum import extract_code
+
+
+class CourseWidget(widgets.ForeignKeyWidget):
+    """Return or create a :class:`Course` from its code and row college."""
+
+    def clean(self, value, row=None, *args, **kwargs):
+        if not value:
+            return None
+        dept_code, course_num = extract_code(value)
+        college_code = row.get("college") if row else None
+        college = None
+        if college_code:
+            college, _ = College.objects.get_or_create(
+                code=college_code,
+                defaults={"fullname": college_code},
+            )
+        course, _ = Course.objects.get_or_create(
+            name=dept_code,
+            number=course_num,
+            college=college,
+            defaults={"title": value},
+        )
+        return course

--- a/app/shared/management/populate_helpers/sections.py
+++ b/app/shared/management/populate_helpers/sections.py
@@ -31,10 +31,8 @@ from typing import IO
 
 from app.shared.management.populate_helpers.utils import log
 from app.timetable.models import Section
-from app.timetable.admin.widgets import (
-    CourseWidget,
-    SemesterWidget,
-)
+from app.academics.admin.widgets import CourseWidget
+from app.timetable.admin.widgets import SemesterWidget
 from app.academics.models import Course
 from app.timetable.models import Semester
 from app.spaces.models import Room

--- a/app/timetable/admin/resources.py
+++ b/app/timetable/admin/resources.py
@@ -5,7 +5,8 @@ from app.academics.models.college import College
 from app.academics.models.course import Course
 from app.timetable.models import AcademicYear, Section, Semester
 
-from .widgets import AcademicYearWidget, CollegeWidget, CourseWidget, SemesterWidget
+from .widgets import AcademicYearWidget, CollegeWidget, SemesterWidget
+from app.academics.admin.widgets import CourseWidget
 
 
 class SectionResource(resources.ModelResource):

--- a/app/timetable/admin/widgets.py
+++ b/app/timetable/admin/widgets.py
@@ -5,6 +5,7 @@ from app.timetable.models import AcademicYear, Semester
 import re
 from datetime import date
 from app.shared.management.populate_helpers.curriculum import extract_code
+from app.academics.admin.widgets import CourseWidget
 
 
 class AcademicYearWidget(widgets.ForeignKeyWidget):
@@ -52,29 +53,6 @@ class CollegeWidget(widgets.ForeignKeyWidget):
             defaults={"fullname": value},
         )
         return obj
-
-
-class CourseWidget(widgets.ForeignKeyWidget):
-    """Return or create a :class:`Course` from its code and row college."""
-
-    def clean(self, value, row=None, *args, **kwargs):
-        if not value:
-            return None
-        dept_code, course_num = extract_code(value)
-        college_code = row.get("college") if row else None
-        college = None
-        if college_code:
-            college, _ = College.objects.get_or_create(
-                code=college_code,
-                defaults={"fullname": college_code},
-            )
-        course, _ = Course.objects.get_or_create(
-            name=dept_code,
-            number=course_num,
-            college=college,
-            defaults={"title": value},
-        )
-        return course
 
 
 class SemesterWidget(widgets.ForeignKeyWidget):


### PR DESCRIPTION
## Summary
- add `app/academics/admin/widgets.py` and place `CourseWidget` there
- re-export `CourseWidget` from `timetable.admin.widgets`
- adjust imports that used the old path

## Testing
- `python3 -m black app/` *(fails: No module named black)*
- `python3 -m flake8 app/` *(fails: No module named flake8)*
- `python3 -m mypy app/` *(fails: No module named mypy)*