### PR TITLE
Fix docs for flake8 command

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -32,5 +32,5 @@ Run them **before every commit**:
 
 ```bash
 black app/                       # auto-format
-flak8 check app/                 # lint (PEP 8 + isort)
+flake8 check app/                 # lint (PEP 8 + isort)
 mypy app/                        # strict typing


### PR DESCRIPTION
## Summary
- fix the flake8 command typo in `agents.md`

## Testing
- `black app/` *(fails: pyenv version not installed)*
- `flake8 app/` *(fails: command not found)*
- `mypy app/` *(fails: pyenv version not installed)*