### PR TITLE
Improve CourseWidget parsing

### DIFF
--- a/app/timetable/admin/widgets.py
+++ b/app/timetable/admin/widgets.py
@@ -2,9 +2,9 @@ from import_export import widgets
 from app.academics.models.college import College
 from app.academics.models.course import Course
 from app.timetable.models import AcademicYear, Semester
+from app.shared.management.populate_helpers.curriculum import extract_code
 import re
 from datetime import date
-from app.shared.management.populate_helpers.curriculum import extract_code
 
 
 class AcademicYearWidget(widgets.ForeignKeyWidget):
@@ -55,25 +55,44 @@ class CollegeWidget(widgets.ForeignKeyWidget):
 
 
 class CourseWidget(widgets.ForeignKeyWidget):
-    """Return or create a :class:`Course` from its code and row college."""
+    """Parse a course code and return or create the matching :class:`Course`."""
 
     def clean(self, value, row=None, *args, **kwargs):
+        """Return the Course object described by ``value``.
+
+        ``value`` may include the college code after a hyphen.  When omitted,
+        the college is taken from ``row['college']`` or defaults to ``"COAS"``.
+        """
+
         if not value:
             return None
-        dept_code, course_num = extract_code(value)
-        college_code = row.get("college") if row else None
-        college = None
-        if college_code:
-            college, _ = College.objects.get_or_create(
-                code=college_code,
-                defaults={"fullname": college_code},
-            )
-        course, _ = Course.objects.get_or_create(
-            name=dept_code,
-            number=course_num,
-            college=college,
-            defaults={"title": value},
+
+        name, number, college_code = extract_code(value, row=row)
+
+        college, _ = College.objects.get_or_create(
+            code=college_code,
+            defaults={"fullname": college_code},
         )
+
+        # find existing course(s) for this triple
+        qs = Course.objects.filter(name=name, number=number, college=college)
+        count = qs.count()
+        code = f"{name}{number}"
+        if count > 1:
+            raise ValueError(
+                f"Integrity Error: Multiple courses found for {code} in {college_code}"
+            )
+        if count == 0:
+            course = Course.objects.create(
+                name=name,
+                number=number,
+                college=college,
+                title=f"Placeholder for {code}",
+                credit_hours=3,
+            )
+        else:
+            course = qs.first()
+
         return course
 
 


### PR DESCRIPTION
## Notes
- formatting and static analysis failed because the environment lacks `black`, `flake8`, and `mypy`

## Summary
- expanded `extract_code` to parse embedded college codes and provide defaults
- simplified `CourseWidget` to rely on the shared parser

## Testing
- `black app/` *(fails: command not found)*
- `flake8 app/` *(fails: command not found)*
- `mypy app/` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*