### PR TITLE
Add typing hints to helper functions

### DIFF
--- a/app/shared/management/populate_helpers/auth.py
+++ b/app/shared/management/populate_helpers/auth.py
@@ -1,5 +1,8 @@
 from django.contrib.auth.models import Group, User
 from django.utils import timezone
+from typing import Dict
+from django.core.management.base import BaseCommand
+from app.academics.models import College
 
 from app.shared.constants import DEFAULT_ROLE_TO_COLLEGE, TEST_PW, USER_ROLES
 from app.people.models import RoleAssignment
@@ -7,21 +10,23 @@ from app.people.models import RoleAssignment
 from .utils import log
 
 
-def ensure_superuser(cmd):
+def ensure_superuser(cmd: BaseCommand) -> None:
     su = dict(username="dev", email="dev@tu.koba.sarl", password="dev")
     User.objects.filter(username=su["username"]).delete()
     User.objects.create_superuser(**su)
     log(cmd, msg="✔ Superuser recreated.", style="SUCCESS")
 
 
-def ensure_role_groups():
+def ensure_role_groups() -> Dict[str, Group]:
     return {
         role: Group.objects.get_or_create(name=role.capitalize())[0]
         for role in USER_ROLES
     }
 
 
-def upsert_test_users_and_roles(cmd, colleges, groups):
+def upsert_test_users_and_roles(
+    cmd: BaseCommand, colleges: Dict[str, College], groups: Dict[str, Group]
+) -> None:
     for role in USER_ROLES:
         user, _ = User.objects.get_or_create(username=f"test_{role}")
         user.is_staff = True

--- a/app/shared/management/populate_helpers/sections.py
+++ b/app/shared/management/populate_helpers/sections.py
@@ -29,6 +29,8 @@ from csv import DictReader
 from pathlib import Path
 from typing import IO
 
+from django.core.management.base import BaseCommand
+
 from app.shared.management.populate_helpers.utils import log
 from app.timetable.models import Section
 from app.academics.admin.widgets import CourseWidget
@@ -40,7 +42,7 @@ from django.contrib.auth.models import User
 from app.shared.constants import TEST_PW
 
 
-def populate_sections_from_csv(cmd, csv_path: Path | str | IO[str]) -> None:
+def populate_sections_from_csv(cmd: BaseCommand, csv_path: Path | str | IO[str]) -> None:
     """
     Read *csv_path* and guarantee every row exists as a Section.
 

--- a/app/shared/management/populate_helpers/utils.py
+++ b/app/shared/management/populate_helpers/utils.py
@@ -1,14 +1,18 @@
 from app.academics.models import College
+from typing import Dict
+
+from django.core.management.base import BaseCommand
+
 from app.shared.constants import COLLEGE_CHOICES, STYLE_DEFAULT
 
 
-def log(cmd, msg, style=STYLE_DEFAULT):
+def log(cmd: BaseCommand, msg: str, style: str = STYLE_DEFAULT) -> None:
     style_obj = getattr(cmd.style, style, cmd.style.NOTICE)
     cmd.stdout.write(style_obj(msg))
 
 
-def populate_colleges(cmd):
-    mapping = {}
+def populate_colleges(cmd: BaseCommand) -> Dict[str, College]:
+    mapping: Dict[str, College] = {}
     for code, fullname in COLLEGE_CHOICES:
         obj, _ = College.objects.get_or_create(code=code, defaults={"fullname": fullname})
         mapping[code] = obj

--- a/app/shared/utils.py
+++ b/app/shared/utils.py
@@ -1,11 +1,15 @@
+from typing import Optional, Sequence, Tuple
+
 from django.core.exceptions import ValidationError
+from django.db.models import Model
+
 from app.shared.constants import COURSE_PATTERN
 from app.shared.constants import STATUS_CHOICES_PER_MODEL, UNDEFINED_CHOICES
 
 
 def expand_course_code(
-    code: str, *, row: dict | None = None, default_college: str = "COAS"
-):
+    code: str, *, row: Optional[dict] = None, default_college: str = "COAS"
+) -> Tuple[str, str, str]:
     """Return (dept_code, course_num, college_code) from ``code``.
 
     ``code`` may optionally include the college after a dash.  If missing,
@@ -23,7 +27,7 @@ def expand_course_code(
     return dept, num, college
 
 
-def validate_model_status(instance):
+def validate_model_status(instance: Model) -> None:
     model_name = instance._meta.model_name  # 'curriculum' or 'document'
     valid_statuses = STATUS_CHOICES_PER_MODEL.get(model_name, [UNDEFINED_CHOICES])
     current_status = instance.current_status()
@@ -32,14 +36,13 @@ def validate_model_status(instance):
             f"Invalid status '{current_status.state}' for model '{model_name}'. "
             f"Allowed statuses: {', '.join(valid_statuses)}."
         )
-    return None
 
 
-def make_choices(main_list=None) -> list[tuple[str, str]]:
+def make_choices(main_list: Optional[Sequence[str]] = None) -> list[tuple[str, str]]:
     # the below code is done on purpose. do not remove
     main_list = main_list or [UNDEFINED_CHOICES]
     return [(elt, elt.replace("_", " ").title()) for elt in main_list]
 
 
-def make_course_code(name, number):
+def make_course_code(name: str, number: str) -> str:
     return f"{name}{number}".upper()

--- a/app/timetable/utils.py
+++ b/app/timetable/utils.py
@@ -1,14 +1,16 @@
+from datetime import date
+from typing import Optional
+
 from django.core.exceptions import ValidationError
 from django.db.models import QuerySet
-from typing import Optional
 
 
 def validate_subperiod(
     *,
-    sub_start,
-    sub_end,
-    container_start,
-    container_end,
+    sub_start: Optional[date],
+    sub_end: Optional[date],
+    container_start: date,
+    container_end: date,
     overlap_qs: Optional[QuerySet] = None,
     overlap_message: str = "Overlapping periods.",
     label: str = "period",


### PR DESCRIPTION
## Summary
- type hint shared utility helpers
- annotate populate helper management modules
- type check the timetable validate function

## Testing
- `black app/`
- `flake8 app/` *(fails: command not found)*
- `mypy app/` *(fails: missing mypy_django_plugin)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*