### PR TITLE
Add duplicate course widget test

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -40,3 +40,29 @@ def test_course_widget_defaults_to_row_college():
     assert course.college == col
     assert course.title == "CHEM100"
     assert College.objects.filter(code="COAS").count() == 1
+
+
+@pytest.mark.django_db
+def test_course_widget_raises_value_error_with_multiple_matches():
+    col = College.objects.create(code="COAS", fullname="College of Arts")
+    Course.objects.create(name="BIO", number="101", title="Bio I", college=col)
+    Course.objects.create(name="BIO", number="101", title="Bio II", college=col)
+    cw = CourseWidget(Course, "code")
+
+    with pytest.raises(ValueError):
+        cw.clean("BIO101 - COAS", {"college": "COAS"})
+
+
+@pytest.mark.django_db
+def test_course_widget_token_college_overrides_row_college():
+    row_college = College.objects.create(code="COAS", fullname="College of Arts")
+    token_college = College.objects.create(code="COET", fullname="College of Engineering")
+    course = Course.objects.create(
+        name="MATH", number="101", title="Math", college=token_college
+    )
+    cw = CourseWidget(Course, "code")
+
+    result = cw.clean("MATH101 - COET", {"college": row_college.code})
+
+    assert result == course
+    assert result.college == token_college


### PR DESCRIPTION
## Summary
- test `CourseWidget` when multiple matches exist
- ensure college code in token overrides row value

## Testing
- `PYENV_VERSION=3.11.12 black tests/test_widgets.py`
- `pip install flake8` *(fails: no network)*
- `PYENV_VERSION=3.11.12 mypy tests/test_widgets.py` *(fails: missing mypy_django_plugin)*