### PR TITLE
Implement basic reservation page

### DIFF
--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -6,7 +6,13 @@ from django.utils import timezone
 from people.models import StudentProfile
 from timetable.models import Section
 
-from app.shared.constants import MAX_STUDENT_CREDITS
+from decimal import Decimal
+
+from app.shared.constants import (
+    MAX_STUDENT_CREDITS,
+    TUITION_RATE_PER_CREDIT,
+    PaymentMethod,
+)
 from app.shared.constants.choices import StatusReservation
 from app.timetable.models.validator import CreditLimitValidator
 
@@ -57,6 +63,15 @@ class Reservation(models.Model):
             .get("total")
             or 0
         )
+
+    # ------------------------------------------------------------------
+    # COMPUTED PROPERTIES
+    # ------------------------------------------------------------------
+    @property
+    def fee_total(self) -> Decimal:
+        """Total fee for this reservation."""
+        credit_hours = self.section.course.credit_hours
+        return credit_hours * TUITION_RATE_PER_CREDIT
 
     # ------------------------------------------------------------------
     # LIFE-CYCLE OVERRIDES

--- a/app/timetable/signals.py
+++ b/app/timetable/signals.py
@@ -1,9 +1,12 @@
 from django.db import transaction
 from django.db.models import Max
-from django.db.models.signals import pre_save
+from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
 
-from app.timetable.models import Section
+from django.db.models import F
+
+from app.timetable.models import Section, Reservation
+from app.shared.constants import StatusReservation
 
 
 @receiver(pre_save, sender=Section)

--- a/app/website/templates/website/landing.html
+++ b/app/website/templates/website/landing.html
@@ -66,6 +66,11 @@
       <div class="container text-center">
         <h3 class="mb-4">This is only the mock-up landing page.</h3>
         <p class="lead">Add whatever sections you need.</p>
+        <p>
+          <a class="btn btn-primary" href="{% url 'student_dashboard' %}">
+            My Reservations
+          </a>
+        </p>
       </div>
     </main>
 

--- a/app/website/templates/website/reservations.html
+++ b/app/website/templates/website/reservations.html
@@ -1,0 +1,39 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>My Reservations</title>
+    <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet" />
+  </head>
+  <body class="p-4">
+    <h1 class="mb-4">My Reservations</h1>
+    {% if messages %}
+    <div class="mb-3">
+      {% for message in messages %}
+        <div class="alert alert-info">{{ message }}</div>
+      {% endfor %}
+    </div>
+    {% endif %}
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Section</th>
+          <th>Status</th>
+          <th>Fee</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in reservations %}
+        <tr>
+          <td>{{ r.section }}</td>
+          <td>{{ r.get_status_display }}</td>
+          <td>{{ r.fee_total }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3">No reservations.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/app/website/urls.py
+++ b/app/website/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 from django.views.generic import TemplateView
 
+from . import views
+
 urlpatterns = [
     # “admin:login” is provided by Django’s admin site
     path("", TemplateView.as_view(template_name="website/landing.html"), name="landing"),
+    path("tuth/reservations/", views.student_dashboard, name="student_dashboard"),
 ]

--- a/app/website/views.py
+++ b/app/website/views.py
@@ -44,6 +44,27 @@ def create_reservation(request, section_id):
     return redirect("student_dashboard")
 
 
+@login_required
+def student_dashboard(request):
+    """List reservations and handle creation via POST."""
+    student = request.user.profile.studentprofile
+    if request.method == "POST":
+        section_id = request.POST.get("section_id")
+        if section_id:
+            return create_reservation(request, section_id)
+
+    reservations = (
+        Reservation.objects.filter(student=student)
+        .select_related("section__course")
+        .order_by("-date_requested")
+    )
+    return render(
+        request,
+        "website/reservations.html",
+        {"reservations": reservations},
+    )
+
+
 def validate_credit_limit(student, section, max_credits=18):
     reserved_credits = (
         Reservation.objects.filter(

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -1,8 +1,10 @@
 import pytest
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from app.people.models import StudentProfile
 from app.timetable.models import Section, Semester, AcademicYear, Reservation
 from app.academics.models import Course, College
+from django.urls import reverse
 
 
 @pytest.mark.django_db
@@ -67,3 +69,10 @@ def test_reservation_mark_paid_creates_payment():
 
     assert reservation.status == "paid"
     assert reservation.payment.amount == reservation.fee_total
+
+@pytest.mark.django_db
+def test_student_dashboard_url(client, superuser):
+    client.force_login(superuser)
+    url = reverse("student_dashboard")
+    resp = client.get(url)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- fix missing imports in `signals` module
- compute tuition using new `fee_total` property
- show reservations via new `student_dashboard` view
- link reservations page from landing page
- test dashboard URL

## Testing
- `black app/ && flake8 app/ && mypy app/` *(fails: command not found)*
- `python3 -m pytest -k reservation -vv` *(fails: No module named pytest)*