### PR TITLE
Add donor profile and scholarship models

### DIFF
--- a/app/finance/admin/core.py
+++ b/app/finance/admin/core.py
@@ -1,9 +1,15 @@
 from django.contrib import admin
 
-from app.finance.models import Payment
+from app.finance.models import Payment, Scholarship
 
 
 @admin.register(Payment)
 class PaymentAdmin(admin.ModelAdmin):
     list_display = ("reservation", "amount", "method", "recorded_by", "created_at")
     readonly_fields = ("created_at",)
+
+
+@admin.register(Scholarship)
+class ScholarshipAdmin(admin.ModelAdmin):
+    list_display = ("student", "donor", "amount", "start_date", "end_date")
+    autocomplete_fields = ("donor", "student")

--- a/app/finance/models/__init__.py
+++ b/app/finance/models/__init__.py
@@ -1,0 +1,16 @@
+"""Convenience exports for finance app models."""
+
+from .payment import Payment
+from .financial_record import FinancialRecord, FeeType, SectionFee
+from .payment_history import PaymentHistory
+from .scholarship import Scholarship
+
+__all__ = [
+    "Payment",
+    "FinancialRecord",
+    "FeeType",
+    "SectionFee",
+    "PaymentHistory",
+    "Scholarship",
+]
+

--- a/app/finance/models/financial_record.py
+++ b/app/finance/models/financial_record.py
@@ -3,7 +3,7 @@ from __future__ import (
 )  # to postpone evaluation of type hints
 
 from app.people.models.profile import StaffProfile, StudentProfile
-from app.shared.constants.choices import FeeTypeLabels
+from app.shared.constants import FeeTypeLabels
 from django.db import models
 
 from app.shared.constants import CLEARANCE_CHOICES

--- a/app/finance/models/payment.py
+++ b/app/finance/models/payment.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from app.people.models.profile import StaffProfile
 from django.db import models
 
-from app.shared.constants.choices import PaymentMethod
+from app.shared.constants import PaymentMethod
 
 class Payment(models.Model):
     """Payment made for a reservation."""

--- a/app/finance/models/scholarship.py
+++ b/app/finance/models/scholarship.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from django.db import models
+
+
+class Scholarship(models.Model):
+    """Financial aid linking a donor to a student."""
+
+    donor = models.ForeignKey(
+        "people.DonorProfile",
+        on_delete=models.CASCADE,
+        related_name="scholarships",
+    )
+    student = models.ForeignKey(
+        "people.StudentProfile",
+        on_delete=models.CASCADE,
+        related_name="scholarships",
+    )
+    amount = models.DecimalField(max_digits=10, decimal_places=2)
+    start_date = models.DateField()
+    end_date = models.DateField(null=True, blank=True)
+    conditions = models.TextField(blank=True)
+
+    def __str__(self) -> str:  # pragma: no cover
+        return f"{self.donor} -> {self.student}"

--- a/app/people/admin.py
+++ b/app/people/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import FacultyProfile
+from .models import FacultyProfile, DonorProfile
 
 
 @admin.register(FacultyProfile)
@@ -13,3 +13,15 @@ class InstructorProfileAdmin(admin.ModelAdmin):
         "department",
     )
     autocomplete_fields = ("user", "college", "courses")
+
+
+@admin.register(DonorProfile)
+class DonorProfileAdmin(admin.ModelAdmin):
+    list_display = ("user", "donor_id")
+    search_fields = (
+        "user__username",
+        "user__first_name",
+        "user__last_name",
+        "donor_id",
+    )
+    autocomplete_fields = ("user",)

--- a/app/people/models/__init__.py
+++ b/app/people/models/__init__.py
@@ -1,4 +1,4 @@
-from .profile import StudentProfile, FacultyProfile
+from .profile import StudentProfile, FacultyProfile, DonorProfile
 from .role_assignment import RoleAssignment
 
-__all__ = ["StudentProfile", "FacultyProfile", "RoleAssignment"]
+__all__ = ["StudentProfile", "FacultyProfile", "DonorProfile", "RoleAssignment"]

--- a/app/people/models/profile.py
+++ b/app/people/models/profile.py
@@ -129,3 +129,18 @@ class FacultyProfile(StaffProfile):
     class Meta(StaffProfile.Meta):
         verbose_name = _("faculty profile")
         verbose_name_plural = _("faculty profiles")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Donor
+# ──────────────────────────────────────────────────────────────────────────────
+class DonorProfile(BaseProfile):
+    """Contact information for donors supporting students."""
+
+    donor_id = models.CharField(max_length=20, unique=True)
+    contact_via_email = models.BooleanField(default=True)
+    contact_via_phone = models.BooleanField(default=False)
+
+    class Meta(BaseProfile.Meta):
+        verbose_name = _("donor profile")
+        verbose_name_plural = _("donor profiles")

--- a/app/registry/models/registration.py
+++ b/app/registry/models/registration.py
@@ -16,7 +16,7 @@ class Registration(models.Model):
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)
     status = models.CharField(
         max_length=30,
-        choices=make_choices(StatusRegistration.choices),
+        choices=StatusRegistration.choices,
         default=StatusRegistration.PENDING,
     )
     #> to update with reservation date

--- a/app/shared/constants/choices.py
+++ b/app/shared/constants/choices.py
@@ -1,5 +1,9 @@
 from django.db import models
 
+# keep this import here so existing modules can simply import StatusRegistration
+# from this file without adjusting paths
+from .registry import StatusRegistration
+
 APPROVED: str = "approved"
 UNDEFINED_CHOICES: str = "undefined_choice"
 

--- a/app/timetable/models/__init__.py
+++ b/app/timetable/models/__init__.py
@@ -2,10 +2,12 @@ from .academic_year import AcademicYear
 from .section import Section
 from .semester import Semester
 from .term import Term
+from .reservation import Reservation
 
 __all__ = [
     "AcademicYear",
     "Term",
     "Semester",
     "Section",
+    "Reservation",
 ]

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -3,8 +3,8 @@ from app.shared.mixins import StatusableMixin
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.utils import timezone
-from people.models import StudentProfile
-from timetable.models import Section
+from app.people.models import StudentProfile
+from .section import Section
 
 from decimal import Decimal
 
@@ -13,7 +13,7 @@ from app.shared.constants import (
     TUITION_RATE_PER_CREDIT,
     PaymentMethod,
 )
-from app.shared.constants.choices import StatusReservation
+from app.shared.constants import StatusReservation
 from app.timetable.models.validator import CreditLimitValidator
 
 

--- a/tests/test_donor_scholarship.py
+++ b/tests/test_donor_scholarship.py
@@ -1,0 +1,40 @@
+import pytest
+from datetime import date
+from django.contrib.auth import get_user_model
+
+from app.people.models import DonorProfile, StudentProfile
+from app.finance.models import Scholarship
+
+
+@pytest.mark.django_db
+def test_donor_profile_creation():
+    User = get_user_model()
+    user = User.objects.create(username="donor")
+    donor = DonorProfile.objects.create(user=user, donor_id="D001")
+
+    assert donor.donor_id == "D001"
+
+
+@pytest.mark.django_db
+def test_scholarship_links_donor_student():
+    User = get_user_model()
+    d_user = User.objects.create(username="donor")
+    s_user = User.objects.create(username="stud")
+
+    donor = DonorProfile.objects.create(user=d_user, donor_id="D002")
+    student = StudentProfile.objects.create(
+        user=s_user,
+        student_id="S001",
+        enrollment_semester=1,
+    )
+
+    scholarship = Scholarship.objects.create(
+        donor=donor,
+        student=student,
+        amount=1000,
+        start_date=date.today(),
+        conditions="Merit based",
+    )
+
+    assert scholarship.donor == donor
+    assert scholarship.student == student


### PR DESCRIPTION
## Summary
- introduce `DonorProfile` under people models
- add new `Scholarship` model relating donors and students
- register donor and scholarship admins
- export models for easier imports
- test donor and scholarship creation
- fix some imports to run tests

## Testing
- `pytest tests/test_donor_scholarship.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'StatusReservation', AssertionError, etc.)*