### PR TITLE
Add type hints for models and helpers

### DIFF
--- a/app/academics/models/course.py
+++ b/app/academics/models/course.py
@@ -4,6 +4,7 @@ from django.db import models
 
 from app.shared.enums import CREDIT_NUMBER, LEVEL_NUMBER
 from app.shared.utils import make_course_code
+from app.academics.models.curriculum import Curriculum
 
 
 class Course(models.Model):
@@ -53,12 +54,12 @@ class Course(models.Model):
             return "other"
 
     @classmethod
-    def for_curriculum(cls, curriculum) -> models.QuerySet:
+    def for_curriculum(cls, curriculum: Curriculum) -> models.QuerySet:
         """Return courses included in the given curriculum."""
         return cls.objects.filter(curricula=curriculum).distinct()
 
     # ---------- hooks ----------
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs) -> None:
         """
         updating course_code on the fly
         """

--- a/app/academics/models/curriculum.py
+++ b/app/academics/models/curriculum.py
@@ -35,7 +35,7 @@ class Curriculum(StatusableMixin, models.Model):
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.title or self.short_name}"
 
-    def clean(self):
+    def clean(self) -> None:
         """Validate the curriculum and its current status."""
 
         super().clean()

--- a/app/academics/models/curriculum_course.py
+++ b/app/academics/models/curriculum_course.py
@@ -56,7 +56,7 @@ class CurriculumCourse(models.Model):
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.curriculum} <-> {self.course}"
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs) -> None:
         if self.credit_hours is None:
             self.credit_hours = self.course.credit_hours
 

--- a/app/people/models/role_assignment.py
+++ b/app/people/models/role_assignment.py
@@ -34,5 +34,5 @@ class RoleAssignment(models.Model):
             models.Index(fields=["role", "college", "end_date"]),
         ]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.user} -> {self.role} ({self.start_date})"

--- a/app/shared/mixins.py
+++ b/app/shared/mixins.py
@@ -2,6 +2,8 @@ from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelatio
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.contrib.auth.models import User
+from typing import Optional
 
 from app.shared.constants import STATUS_CHOICES
 
@@ -39,22 +41,23 @@ class StatusableMixin(models.Model):
     )
 
     # ─── helpers ──────────────────────────────────────────────
-    def _add_status(self, state: str, author):
+    def _add_status(self, state: str, author: Optional[User]) -> StatusHistory:
+        """Helper to append a new status entry."""
         return self.status_history.create(state=state, author=author)
 
-    def current_status(self):
+    def current_status(self) -> Optional[StatusHistory]:
         return self.status_history.first()
 
-    def set_pending(self, author):
+    def set_pending(self, author: Optional[User]) -> StatusHistory:
         return self._add_status("pending", author)
 
-    def set_revision(self, author):
+    def set_revision(self, author: Optional[User]) -> StatusHistory:
         return self._add_status("needs_revision", author)
 
-    def set_approved(self, author):
+    def set_approved(self, author: Optional[User]) -> StatusHistory:
         return self._add_status("approved", author)
 
-    def set_rejected(self, author):
+    def set_rejected(self, author: Optional[User]) -> StatusHistory:
         return self._add_status("rejected", author)
 
     def validate_state(self, allowed: list[str]) -> None:

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -40,10 +40,10 @@ class Reservation(StatusableMixin, models.Model):
         credit_hours = self.section.course.credit_hours
         return credit_hours * TUITION_RATE_PER_CREDIT
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.student} -> {self.section} ({self.status})"
 
-    def _check_credit_limit(self):
+    def _check_credit_limit(self) -> None:
         prospective = self.credit_hours() + self.section.course.credit_hours
         if prospective > MAX_STUDENT_CREDITS:
             raise ValidationError(
@@ -74,7 +74,7 @@ class Reservation(StatusableMixin, models.Model):
     # ------------------------------------------------------------------
     # LIFE-CYCLE OVERRIDES
     # ------------------------------------------------------------------
-    def clean(self):
+    def clean(self) -> None:
         """Model-level validation before every save()."""
         super().clean()
 
@@ -85,14 +85,14 @@ class Reservation(StatusableMixin, models.Model):
         # apply credit-hour rule, the idea is that we may reuse this elsewhere
         CreditLimitValidator()(self)
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs) -> None:
         super().save(*args, **kwargs)
 
     # ------------------------------------------------------------------
     # USER-FACING OPERATIONS
     # ------------------------------------------------------------------
     @transaction.atomic
-    def validate(self):
+    def validate(self) -> None:
         """Finance / Registrar marks the reservation as validated."""
         if self.status == StatusReservation.VALIDATED:
             raise ValueError("Reservation already validated.")
@@ -101,14 +101,14 @@ class Reservation(StatusableMixin, models.Model):
         self.full_clean()
         self.save(update_fields=["status", "date_validated"])
 
-    def cancel(self):
+    def cancel(self) -> None:
         assert (
             self.status != StatusReservation.CANCELLED
         ), "Reservation already cancelled."
         self.status = StatusReservation.CANCELLED
         self.save()
 
-    def mark_paid(self, by_user):
+    def mark_paid(self, by_user: models.Model) -> None:
         """Record payment and mark reservation as paid."""
 
         if self.status == StatusReservation.PAID:

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -65,6 +65,6 @@ class Section(models.Model):
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.long_code} | {self.room}"
 
-    def has_available_seats(self):
+    def has_available_seats(self) -> bool:
         """Return 'True' if the section still has seats available."""
         return self.current_registrations < self.max_seats

--- a/app/timetable/models/term.py
+++ b/app/timetable/models/term.py
@@ -17,7 +17,7 @@ class Term(models.Model):
     start_date = models.DateField(null=True, blank=True)
     end_date = models.DateField(null=True, blank=True)
 
-    def clean(self):
+    def clean(self) -> None:
         container_start = self.semester.start_date
         container_end = self.semester.end_date
         assert container_start is not None and container_end is not None

--- a/app/timetable/models/validator.py
+++ b/app/timetable/models/validator.py
@@ -1,12 +1,13 @@
 from django.core.exceptions import ValidationError
 
 from app.shared.constants import MAX_STUDENT_CREDITS
+from app.timetable.models.reservation import Reservation
 
 
 class CreditLimitValidator:
     """Ensure a student's reservation doesn't exceed the credit limit."""
 
-    def __call__(self, reservation):
+    def __call__(self, reservation: Reservation) -> None:
         # compute the hours the student would have if this reservation succeeds
         prospective = reservation.credit_hours() + reservation.section.course.credit_hours
         if prospective > MAX_STUDENT_CREDITS:


### PR DESCRIPTION
## Summary
- annotate course, curriculum and registration models
- type hint status mixin utilities
- document types in reservation logic

## Testing
- `black app/...` *(fails: command not found)*
- `flake8 app/...` *(fails: command not found)*
- `mypy app/...` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c874108208323bd1f9e772050f4b3