### PR TITLE
Add WEEKDAYS_NUMBER enum

### DIFF
--- a/app/shared/enums.py
+++ b/app/shared/enums.py
@@ -28,3 +28,14 @@ class LEVEL_NUMBER(IntegerChoices):
     THREE = 3, "junior"
     FOUR = 4, "senior"
     FIVE = 5, "senior"
+
+
+class WEEKDAYS_NUMBER(IntegerChoices):
+    """Integer representation of weekdays."""
+
+    MONDAY = 1, "Monday"
+    TUESDAY = 2, "Tuesday"
+    WEDNESDAY = 3, "Wednesday"
+    THURSDAY = 4, "Thursday"
+    FRIDAY = 5, "Friday"
+    SATURDAY = 6, "Saturday"

--- a/tests/test_weekdays_enum.py
+++ b/tests/test_weekdays_enum.py
@@ -1,0 +1,5 @@
+from app.shared.enums import WEEKDAYS_NUMBER
+
+
+def test_monday_is_one():
+    assert WEEKDAYS_NUMBER.MONDAY == 1


### PR DESCRIPTION
## Notes
- Introduces a `WEEKDAYS_NUMBER` enumeration in `app/shared/enums.py`
- `Schedule` model already imports this enumeration
- Adds a simple test verifying Monday maps to 1

## Testing
- `black app/shared/enums.py tests/test_weekdays_enum.py --line-length 90`
- `flake8 app/shared/enums.py tests/test_weekdays_enum.py`
- `pytest -k test_monday_is_one -q` *(fails: ImportError due to circular import in project)*

------
https://chatgpt.com/codex/tasks/task_e_683e2332cb0883238006ec63a7eaf2ca