### PR TITLE
Update schedule import

### DIFF
--- a/app/shared/management/commands/import_schedule.py
+++ b/app/shared/management/commands/import_schedule.py
@@ -11,9 +11,11 @@ from app.academics.admin.widgets import CourseWidget, CollegeWidget
 from app.academics.models import College, Course, Curriculum, CurriculumCourse
 from app.people.models import FacultyProfile
 from app.shared.constants import TEST_PW
+from app.spaces.admin import RoomWidget
 from app.spaces.models import Room
 from app.timetable.admin.widgets import SemesterWidget
-from app.timetable.models import Section, Semester
+from app.timetable.models import Schedule, Section, Semester
+from django.utils.dateparse import parse_date, parse_time
 
 
 # ./academics/admin/resources.py: class CollegeResource
@@ -68,10 +70,9 @@ class Command(BaseCommand):
         cw = CourseWidget(model=Course, field="code")
         clg_w = CollegeWidget(model=College, field="code")
         sw = SemesterWidget(model=Semester, field="id")
+        rw = RoomWidget(model=Room, field="name")
 
-        added_sections = added_curricula = added_curriculum_courses = added_faculty = (
-            skipped
-        ) = 0
+        added_sections = added_curricula = added_curriculum_courses = added_faculty = skipped = 0
 
         with path.open(newline="", encoding="utf-8") as fh:
             reader = csv.DictReader(fh)
@@ -82,9 +83,15 @@ class Command(BaseCommand):
                     course = cw.clean(f'{row["course_code"]}{row["course_no"]}', row)
                     semester = sw.clean(row["semester"], row)
                     section_no = int(row["section"]) if row["section"].strip() else 1
-                    room_id = _ensure_room(row["location"])
-                    faculty = _ensure_faculty(row["instructor"], college)
-                    curriculum = _ensure_curriculum(row["curriculum"], college)
+                    room = rw.clean(row.get("location"))
+                    faculty = _ensure_faculty(row.get("instructor"), college)
+                    curriculum = _ensure_curriculum(row.get("curriculum"), college)
+
+                    weekday = _parse_weekday(row.get("weekday") or row.get("days"))
+                    start_time, end_time = _parse_times(row["time_start"], row["time_end"])
+                    schedule = _ensure_schedule(weekday, start_time, end_time, room, faculty)
+                    start_date = parse_date((row.get("sts") or "")[:10])
+                    end_date = parse_date((row.get("ets") or "")[:10])
 
                     if dry_run:
                         continue
@@ -94,14 +101,17 @@ class Command(BaseCommand):
                         semester=semester,
                         number=section_no,
                         defaults={
-                            "room_id": room_id,
+                            "room": room,
                             "faculty": faculty,
                             "max_seats": 30,
-                            "schedule": _human_time(row),
+                            "schedule": schedule,
+                            "start_date": start_date,
+                            "end_date": end_date,
                         },
                     )
                     if created:
                         added_sections += 1
+                        self.stdout.write(self.style.SUCCESS(f"  ↳ section {section.long_code}"))
 
                     # Link course to curriculum
                     cc, cc_created = CurriculumCourse.objects.get_or_create(
@@ -117,17 +127,9 @@ class Command(BaseCommand):
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"{added_sections} sections, {added_faculty} faculty, "
-                f"{added_curricula} curricula, {added_curriculum_courses} curriculum-courses added, {skipped} skipped."
+                f"{added_sections} sections, {added_curriculum_courses} curriculum-courses added, {skipped} skipped."
             )
         )
-
-
-def _ensure_room(raw: str) -> int | None:
-    if not raw or raw.lower() == "nan":
-        return None
-    room, _ = Room.objects.get_or_create(name=raw.strip())
-    return room.id
 
 
 def _ensure_faculty(raw: str, college: College) -> FacultyProfile | None:
@@ -158,8 +160,35 @@ def _ensure_curriculum(curriculum_title: str, college: College) -> Curriculum:
     return curriculum
 
 
-def _human_time(row: dict[str, str]) -> str:
-    weekday = row.get("weekday") or row.get("days")
-    if not weekday:
-        raise ValueError("Missing 'weekday' or 'days' in row.")
-    return f'{weekday[:3]} {row["time_start"]}-{row["time_end"]}'
+def _parse_weekday(raw: str) -> int:
+    mapping = {
+        "mon": 1,
+        "tue": 2,
+        "wed": 3,
+        "thu": 4,
+        "fri": 5,
+        "sat": 6,
+        "sun": 7,
+    }
+    token = (raw or "").strip().lower()[:3]
+    if token not in mapping:
+        raise ValueError(f"Invalid weekday '{raw}'")
+    return mapping[token]
+
+
+def _parse_times(start: str, end: str):
+    st = parse_time(start)
+    et = parse_time(end)
+    if st is None or et is None:
+        raise ValueError("Invalid time values")
+    return st, et
+
+
+def _ensure_schedule(weekday: int, start_time, end_time, room: Room | None, faculty: FacultyProfile | None) -> Schedule:
+    obj, _ = Schedule.objects.get_or_create(
+        weekday=weekday,
+        start_time=start_time,
+        end_time=end_time,
+        defaults={"room": room, "faculty": faculty},
+    )
+    return obj

--- a/app/spaces/admin/__init__.py
+++ b/app/spaces/admin/__init__.py
@@ -1,5 +1,5 @@
 from .core import BuildingAdmin, RoomAdmin
 from .resources import RoomResource
-from .widgets import BuildingWidget
+from .widgets import BuildingWidget, RoomWidget
 
-__all__ = ["RoomResource", "BuildingWidget", "BuildingAdmin", "RoomAdmin"]
+__all__ = ["RoomResource", "BuildingWidget", "RoomWidget", "BuildingAdmin", "RoomAdmin"]

--- a/app/spaces/admin/widgets.py
+++ b/app/spaces/admin/widgets.py
@@ -1,6 +1,6 @@
 from import_export import widgets
 
-from app.spaces.models import Building
+from app.spaces.models import Building, Room
 
 
 class BuildingWidget(widgets.ForeignKeyWidget):
@@ -18,3 +18,21 @@ class BuildingWidget(widgets.ForeignKeyWidget):
             defaults={"full_name": value},  # or leave blank / supply something smarter
         )
         return obj
+
+
+class RoomWidget(widgets.ForeignKeyWidget):
+    """Resolve "B1-101" strings into Room objects."""
+
+    def clean(self, value, row=None, *args, **kwargs):
+        if not value:
+            return None
+
+        token = value.strip()
+        if "-" not in token:
+            Building.objects.get_or_create(short_name=token)
+            return None
+
+        building_code, room_name = token.split("-", 1)
+        building, _ = Building.objects.get_or_create(short_name=building_code)
+        room, _ = Room.objects.get_or_create(name=room_name, building=building)
+        return room

--- a/tests/test_import_schedule.py
+++ b/tests/test_import_schedule.py
@@ -1,0 +1,24 @@
+import io
+import pytest
+from django.core.management import call_command
+from app.timetable.models import Section, Schedule, Semester
+from app.academics.models import College
+
+
+@pytest.mark.django_db
+def test_import_schedule_creates_section(tmp_path):
+    csv = io.StringIO(
+        "college,course_code,course_no,semester,section,location,instructor,curriculum,weekday,time_start,time_end,sts,ets\n"
+        "COAS,MATH,101,24-25_Sem1,1,B1-101,John Doe,BSCS,Mon,08:00,09:00,2024-09-01,2024-09-30\n"
+    )
+    path = tmp_path / "sched.csv"
+    path.write_text(csv.getvalue())
+
+    call_command("import_schedule", str(path))
+
+    section = Section.objects.get()
+    schedule = Schedule.objects.get()
+
+    assert section.schedule == schedule
+    assert section.start_date.isoformat() == "2024-09-01"
+    assert section.end_date.isoformat() == "2024-09-30"


### PR DESCRIPTION
## Summary
- implement `RoomWidget` to create buildings & rooms
- hook `import_schedule` with new helpers, parse times, and create `Schedule`
- connect the resulting schedule to each section
- add a regression test for importing schedules

## Testing
- `pytest -q tests/test_import_schedule.py -vv` *(fails: ImportError: cannot import name 'Reservation' from partially initialized module 'app.timetable.models.reservation')*

------
https://chatgpt.com/codex/tasks/task_e_683e233b408c8323a257019417866c0c