### PR TITLE
Implement faculty helper and tests

### DIFF
--- a/app/shared/management/commands/import_schedule.py
+++ b/app/shared/management/commands/import_schedule.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import csv
 from pathlib import Path
 
-from django.contrib.auth.models import User
+from app.people.models.profile import _ensure_faculty
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from app.academics.admin.widgets import CourseWidget, CollegeWidget
 from app.academics.models import College, Course, Curriculum, CurriculumCourse
-from app.people.models import FacultyProfile
-from app.shared.constants import TEST_PW
 from app.spaces.models import Room
 from app.timetable.admin.widgets import SemesterWidget
 from app.timetable.models import Section, Semester
@@ -130,24 +128,6 @@ def _ensure_room(raw: str) -> int | None:
     return room.id
 
 
-def _ensure_faculty(raw: str, college: College) -> FacultyProfile | None:
-    if not raw or raw.lower() == "nan":
-        return None
-    fullname = raw.strip()
-    username = fullname.replace(" ", "_").lower()
-    user, created = User.objects.get_or_create(
-        username=username, fullname=fullname, defaults={"password": TEST_PW}
-    )
-
-    if created:
-        user.set_password(TEST_PW)
-        user.save()
-
-    faculty_profile, fp_created = FacultyProfile.objects.get_or_create(
-        user=user, defaults={"college": college}
-    )
-
-    return faculty_profile
 
 
 def _ensure_curriculum(curriculum_title: str, college: College) -> Curriculum:

--- a/tests/test_faculty_helper.py
+++ b/tests/test_faculty_helper.py
@@ -1,0 +1,34 @@
+import pytest
+from django.contrib.auth.models import User
+
+from app.academics.models import College
+from app.people.models.profile import _ensure_faculty, FacultyProfile
+from app.shared.constants import TEST_PW
+
+
+@pytest.mark.django_db
+def test_ensure_faculty_creates_user_and_profile():
+    col = College.objects.create(code="COAS", fullname="College of Arts")
+
+    prof = _ensure_faculty("Jane Doe", col)
+
+    assert prof.college == col
+    user = prof.user
+    assert user.username == "j.doe"
+    assert user.first_name == "Jane"
+    assert user.last_name == "Doe"
+    assert user.check_password(TEST_PW)
+
+    assert User.objects.count() == 1
+    assert FacultyProfile.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_ensure_faculty_is_idempotent():
+    col = College.objects.create(code="COAS", fullname="College of Arts")
+    prof1 = _ensure_faculty("Jane Doe", col)
+    prof2 = _ensure_faculty("Jane Doe", col)
+
+    assert prof1.id == prof2.id
+    assert User.objects.count() == 1
+    assert FacultyProfile.objects.count() == 1


### PR DESCRIPTION
## Summary
- add `_ensure_faculty` helper in `profile` to create user + profile
- refactor `import_schedule` to reuse the helper
- add unit tests for faculty helper logic

## Testing
- `python3.12 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_683e2346e21483239e36202687ef2dff