### PR TITLE
Add schedule import docs

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,3 +72,20 @@ or XLSX files and to download existing records. Models such as
 Courses, Curricula and Sections already provide corresponding
 resources.
 
+** Schedule Import
+
+Follow this sequence to reset the database and load a schedule CSV:
+
+#+begin_src bash
+docker-compose -f docker-compose-dev.yml exec web python manage.py reset_db
+docker-compose -f docker-compose-dev.yml exec web python manage.py makemigrations
+docker-compose -f docker-compose-dev.yml exec web python manage.py migrate
+docker-compose -f docker-compose-dev.yml exec web python manage.py import_schedule Seed_data/tu_schedule_Sem1_24-25_b.csv
+#+end_src
+
+The command summarizes how many *sections*, *faculty*, *curricula* and
+*curriculum‑courses* were created and any skipped rows.
+
+After completion, log in to =/admin/= and check the Courses, Colleges,
+Rooms and Sections pages to verify the imported data.
+


### PR DESCRIPTION
## Summary
- document how to reset the database and import the sample schedule
- show how to confirm new objects using the Django admin

## Testing
- `black app/`
- `flake8 app/` *(fails: command not found)*
- `mypy app/` *(fails: No module named 'mypy_django_plugin')*
- `docker-compose -f docker-compose-dev.yml run --rm web pytest tests/` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e234d9bc48323a97a5a4e2f64b6fc