### PR TITLE
Add module-level docstrings

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the app package."""

--- a/app/academics/__init__.py
+++ b/app/academics/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the academics package."""

--- a/app/academics/admin/__init__.py
+++ b/app/academics/admin/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the admin package."""
+
 from .core import (
     CollegeAdmin,
     CourseAdmin,

--- a/app/academics/admin/actions.py
+++ b/app/academics/admin/actions.py
@@ -1,3 +1,5 @@
+"""Actions module."""
+
 # app/academics/admin/actions.py
 from django.contrib import admin, messages
 from django.shortcuts import render, redirect

--- a/app/academics/admin/core.py
+++ b/app/academics/admin/core.py
@@ -1,3 +1,5 @@
+"""Core module."""
+
 from django.contrib import admin
 from guardian.admin import GuardedModelAdmin
 from import_export.admin import ImportExportModelAdmin

--- a/app/academics/admin/filters.py
+++ b/app/academics/admin/filters.py
@@ -1,3 +1,5 @@
+"""Filters module."""
+
 from django.contrib import admin
 from app.academics.models import Curriculum
 

--- a/app/academics/admin/forms.py
+++ b/app/academics/admin/forms.py
@@ -1,3 +1,5 @@
+"""Forms module."""
+
 # app/academics/admin/forms.py
 from typing import Any, MutableMapping, cast
 from django import forms

--- a/app/academics/admin/inlines.py
+++ b/app/academics/admin/inlines.py
@@ -1,3 +1,5 @@
+"""Inlines module."""
+
 from django.contrib import admin
 
 from app.academics.models import Prerequisite, CurriculumCourse

--- a/app/academics/admin/resources.py
+++ b/app/academics/admin/resources.py
@@ -1,3 +1,5 @@
+"""Resources module."""
+
 from django.contrib import messages
 from import_export import fields, resources, widgets
 

--- a/app/academics/admin/widgets.py
+++ b/app/academics/admin/widgets.py
@@ -1,3 +1,5 @@
+"""Widgets module."""
+
 from datetime import date
 
 from import_export import widgets

--- a/app/academics/apps.py
+++ b/app/academics/apps.py
@@ -1,3 +1,5 @@
+"""Apps module."""
+
 # app/academics/apps.py
 from django.apps import AppConfig
 

--- a/app/academics/models/__init__.py
+++ b/app/academics/models/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the models package."""
+
 from .college import College
 from .concentration import Concentration
 from .course import Course

--- a/app/academics/models/college.py
+++ b/app/academics/models/college.py
@@ -1,3 +1,5 @@
+"""College module."""
+
 from __future__ import annotations
 
 from django.core.exceptions import ValidationError

--- a/app/academics/models/concentration.py
+++ b/app/academics/models/concentration.py
@@ -1,3 +1,5 @@
+"""Concentration module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/academics/models/course.py
+++ b/app/academics/models/course.py
@@ -1,3 +1,5 @@
+"""Course module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/academics/models/curriculum.py
+++ b/app/academics/models/curriculum.py
@@ -1,3 +1,5 @@
+"""Curriculum module."""
+
 from __future__ import annotations
 from datetime import date
 

--- a/app/academics/models/curriculum_course.py
+++ b/app/academics/models/curriculum_course.py
@@ -1,3 +1,5 @@
+"""Curriculum course module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/academics/models/prerequisite.py
+++ b/app/academics/models/prerequisite.py
@@ -1,3 +1,5 @@
+"""Prerequisite module."""
+
 from __future__ import annotations
 
 from django.core.exceptions import ValidationError

--- a/app/academics/signals.py
+++ b/app/academics/signals.py
@@ -1,3 +1,5 @@
+"""Signals module."""
+
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 

--- a/app/finance/__init__.py
+++ b/app/finance/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the finance package."""

--- a/app/finance/admin/__init__.py
+++ b/app/finance/admin/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the admin package."""
+
 from app.finance.admin.core import PaymentAdmin
 
 

--- a/app/finance/admin/core.py
+++ b/app/finance/admin/core.py
@@ -1,3 +1,5 @@
+"""Core module."""
+
 from django.contrib import admin
 
 from app.finance.models import Payment, Scholarship

--- a/app/finance/apps.py
+++ b/app/finance/apps.py
@@ -1,3 +1,5 @@
+"""Apps module."""
+
 # app/finance/apps.py
 from django.apps import AppConfig
 

--- a/app/finance/models/financial_record.py
+++ b/app/finance/models/financial_record.py
@@ -1,3 +1,5 @@
+"""Financial record module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/finance/models/payment.py
+++ b/app/finance/models/payment.py
@@ -1,3 +1,5 @@
+"""Payment module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/finance/models/payment_history.py
+++ b/app/finance/models/payment_history.py
@@ -1,3 +1,5 @@
+"""Payment history module."""
+
 from __future__ import annotations  # to postpone evaluation of type hints
 
 from django.db import models

--- a/app/finance/models/scholarship.py
+++ b/app/finance/models/scholarship.py
@@ -1,3 +1,5 @@
+"""Scholarship module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/finance/utils.py
+++ b/app/finance/utils.py
@@ -1,3 +1,5 @@
+"""Utils module."""
+
 from decimal import Decimal
 
 from app.shared.constants import TUITION_RATE_PER_CREDIT

--- a/app/people/__init__.py
+++ b/app/people/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the people package."""

--- a/app/people/admin/__init__.py
+++ b/app/people/admin/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the admin package."""
+
 from .core import StudentProfileAdmin, DonorProfileAdmin, InstructorProfileAdmin
 
 __all__ = ["InstructorProfileAdmin", "DonorProfileAdmin", "StudentProfileAdmin"]

--- a/app/people/admin/core.py
+++ b/app/people/admin/core.py
@@ -1,3 +1,5 @@
+"""Core module."""
+
 from django.contrib import admin
 
 from app.people.models import FacultyProfile, DonorProfile, StudentProfile

--- a/app/people/admin/resources.py
+++ b/app/people/admin/resources.py
@@ -1,3 +1,5 @@
+"""Resources module."""
+
 from app.people.models import StudentProfile
 from app.registry.models import Registration
 

--- a/app/people/apps.py
+++ b/app/people/apps.py
@@ -1,3 +1,5 @@
+"""Apps module."""
+
 # app/people/apps.py
 from django.apps import AppConfig
 

--- a/app/people/models/__init__.py
+++ b/app/people/models/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the models package."""
+
 from .profile import StudentProfile, FacultyProfile, DonorProfile
 from .role_assignment import RoleAssignment
 

--- a/app/people/models/profile.py
+++ b/app/people/models/profile.py
@@ -1,3 +1,5 @@
+"""Profile module."""
+
 # app/people/models/profile.py
 from __future__ import annotations
 

--- a/app/people/models/role_assignment.py
+++ b/app/people/models/role_assignment.py
@@ -1,3 +1,5 @@
+"""Role assignment module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/registry/__init__.py
+++ b/app/registry/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the registry package."""

--- a/app/registry/apps.py
+++ b/app/registry/apps.py
@@ -1,3 +1,5 @@
+"""Apps module."""
+
 # app/registry/apps.py
 from django.apps import AppConfig
 

--- a/app/registry/models/__init__.py
+++ b/app/registry/models/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the models package."""
+
 from .class_roster import ClassRoster
 from .document import Document
 from .registration import Registration

--- a/app/registry/models/class_roster.py
+++ b/app/registry/models/class_roster.py
@@ -1,3 +1,5 @@
+"""Class roster module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/registry/models/document.py
+++ b/app/registry/models/document.py
@@ -1,3 +1,5 @@
+"""Document module."""
+
 from __future__ import annotations
 
 from typing import Optional, cast

--- a/app/registry/models/registration.py
+++ b/app/registry/models/registration.py
@@ -1,3 +1,5 @@
+"""Registration module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/shared/__init__.py
+++ b/app/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the shared package."""

--- a/app/shared/apps.py
+++ b/app/shared/apps.py
@@ -1,3 +1,5 @@
+"""Apps module."""
+
 # app/shared/apps.py
 from django.apps import AppConfig
 

--- a/app/shared/constants/__init__.py
+++ b/app/shared/constants/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the constants package."""
+
 from itertools import chain
 from typing import List, Tuple
 

--- a/app/shared/constants/academics.py
+++ b/app/shared/constants/academics.py
@@ -1,3 +1,5 @@
+"""Academics module."""
+
 from django.db import models
 import re
 

--- a/app/shared/constants/curriculum.py
+++ b/app/shared/constants/curriculum.py
@@ -1,3 +1,5 @@
+"""Curriculum module."""
+
 # code should absolutely be 6 char long, else will fail.
 TEST_ENVIRONMENTAL_STUDIES_CURRICULUM = [
     ("24-25_Sem1", "COAS", "ENG101", "Grammar and Phonetics", 3, ""),

--- a/app/shared/constants/finance.py
+++ b/app/shared/constants/finance.py
@@ -1,3 +1,5 @@
+"""Finance module."""
+
 from decimal import Decimal
 from django.db import models
 

--- a/app/shared/constants/perms.py
+++ b/app/shared/constants/perms.py
@@ -1,3 +1,5 @@
+"""Perms module."""
+
 from django.db import models
 
 TEST_PW = "test"

--- a/app/shared/constants/registry.py
+++ b/app/shared/constants/registry.py
@@ -1,3 +1,5 @@
+"""Registry module."""
+
 from django.db import models
 
 

--- a/app/shared/constants/timetable.py
+++ b/app/shared/constants/timetable.py
@@ -1,3 +1,5 @@
+"""Timetable module."""
+
 from django.db import models
 
 

--- a/app/shared/enums.py
+++ b/app/shared/enums.py
@@ -1,12 +1,16 @@
+"""Enums module."""
+
 from django.db.models import IntegerChoices
+
 
 class WEEKDAYS_NUMBER(IntegerChoices):
     MONDAY = 1, "Monday"
     TUESDAY = 2, "Tuesday"
     WEDNESDAY = 3, "Wednesday"
     THURSDAY = 4, "Thursday"
-    FRIDAY = 5, "Friday"    
+    FRIDAY = 5, "Friday"
     SATURDAY = 6, "Saturday"
+
 
 class SEMESTER_NUMBER(IntegerChoices):
     FIRST = 1, "First"

--- a/app/shared/forms.py
+++ b/app/shared/forms.py
@@ -1,3 +1,5 @@
+"""Forms module."""
+
 from django import forms
 from django.core.exceptions import FieldDoesNotExist
 from django.forms import ChoiceField

--- a/app/shared/management/__init__.py
+++ b/app/shared/management/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the management package."""

--- a/app/shared/management/commands/__init__.py
+++ b/app/shared/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the commands package."""

--- a/app/shared/management/commands/import_schedule.py
+++ b/app/shared/management/commands/import_schedule.py
@@ -1,3 +1,5 @@
+"""Import schedule module."""
+
 from __future__ import annotations
 
 import csv
@@ -88,8 +90,12 @@ class Command(BaseCommand):
                     curriculum = _ensure_curriculum(row.get("curriculum"), college)
 
                     weekday = _parse_weekday(row.get("weekday") or row.get("days"))
-                    start_time, end_time = _parse_times(row["time_start"], row["time_end"])
-                    schedule = _ensure_schedule(weekday, start_time, end_time, room, faculty)
+                    start_time, end_time = _parse_times(
+                        row["time_start"], row["time_end"]
+                    )
+                    schedule = _ensure_schedule(
+                        weekday, start_time, end_time, room, faculty
+                    )
                     start_date = parse_date((row.get("sts") or "")[:10])
                     end_date = parse_date((row.get("ets") or "")[:10])
 
@@ -111,7 +117,9 @@ class Command(BaseCommand):
                     )
                     if created:
                         added_sections += 1
-                        self.stdout.write(self.style.SUCCESS(f"  ↳ section {section.long_code}"))
+                        self.stdout.write(
+                            self.style.SUCCESS(f"  ↳ section {section.long_code}")
+                        )
 
                     # Link course to curriculum
                     cc, cc_created = CurriculumCourse.objects.get_or_create(
@@ -130,8 +138,6 @@ class Command(BaseCommand):
                 f"{added_sections} sections, {added_curriculum_courses} curriculum-courses added, {skipped} skipped."
             )
         )
-
-
 
 
 def _ensure_curriculum(curriculum_title: str, college: College) -> Curriculum:
@@ -166,7 +172,9 @@ def _parse_times(start: str, end: str):
     return st, et
 
 
-def _ensure_schedule(weekday: int, start_time, end_time, room: Room | None, faculty: FacultyProfile | None) -> Schedule:
+def _ensure_schedule(
+    weekday: int, start_time, end_time, room: Room | None, faculty: FacultyProfile | None
+) -> Schedule:
     obj, _ = Schedule.objects.get_or_create(
         weekday=weekday,
         start_time=start_time,

--- a/app/shared/management/commands/import_workbook.py
+++ b/app/shared/management/commands/import_workbook.py
@@ -1,3 +1,5 @@
+"""Import workbook module."""
+
 from __future__ import annotations
 
 import re

--- a/app/shared/management/commands/populate_initial_data.py
+++ b/app/shared/management/commands/populate_initial_data.py
@@ -1,3 +1,5 @@
+"""Populate initial data module."""
+
 from pathlib import Path
 from app.shared.management.populate_helpers.from_csv import (
     populate_curricula_from_csv,

--- a/app/shared/management/commands/reset_db.py
+++ b/app/shared/management/commands/reset_db.py
@@ -1,3 +1,5 @@
+"""Reset db module."""
+
 from django.core.management.base import BaseCommand
 from django.db import connection
 

--- a/app/shared/management/populate_helpers/auth.py
+++ b/app/shared/management/populate_helpers/auth.py
@@ -1,3 +1,5 @@
+"""Auth module."""
+
 from app.shared.constants.perms import UserRole
 from django.contrib.auth.models import Group, User
 from django.utils import timezone

--- a/app/shared/management/populate_helpers/from_csv.py
+++ b/app/shared/management/populate_helpers/from_csv.py
@@ -1,3 +1,5 @@
+"""From csv module."""
+
 from __future__ import annotations
 
 from csv import DictReader

--- a/app/shared/management/populate_helpers/perms.py
+++ b/app/shared/management/populate_helpers/perms.py
@@ -1,3 +1,5 @@
+"""Perms module."""
+
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from guardian.shortcuts import assign_perm

--- a/app/shared/management/populate_helpers/utils.py
+++ b/app/shared/management/populate_helpers/utils.py
@@ -1,3 +1,5 @@
+"""Utils module."""
+
 from app.academics.models import College
 from typing import Dict
 

--- a/app/shared/mixins.py
+++ b/app/shared/mixins.py
@@ -1,3 +1,5 @@
+"""Mixins module."""
+
 from typing import Any, Iterable
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType

--- a/app/shared/utils.py
+++ b/app/shared/utils.py
@@ -1,3 +1,5 @@
+"""Utils module."""
+
 from typing import Mapping, Optional, Tuple
 
 from app.shared.constants import COURSE_PATTERN

--- a/app/spaces/__init__.py
+++ b/app/spaces/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the spaces package."""

--- a/app/spaces/admin/__init__.py
+++ b/app/spaces/admin/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the admin package."""
+
 from .core import BuildingAdmin, RoomAdmin
 from .resources import RoomResource
 from .widgets import BuildingWidget, RoomWidget

--- a/app/spaces/admin/core.py
+++ b/app/spaces/admin/core.py
@@ -1,3 +1,5 @@
+"""Core module."""
+
 from app.timetable.admin.inlines import SectionInline
 from django.contrib import admin
 from guardian.admin import GuardedModelAdmin

--- a/app/spaces/admin/resources.py
+++ b/app/spaces/admin/resources.py
@@ -1,3 +1,5 @@
+"""Resources module."""
+
 from import_export import fields, resources
 from app.spaces.models import Room, Building
 

--- a/app/spaces/admin/widgets.py
+++ b/app/spaces/admin/widgets.py
@@ -1,3 +1,5 @@
+"""Widgets module."""
+
 from import_export import widgets
 
 from app.spaces.models import Building, Room

--- a/app/spaces/apps.py
+++ b/app/spaces/apps.py
@@ -1,3 +1,5 @@
+"""Apps module."""
+
 # app/spaces/apps.py
 from django.apps import AppConfig
 

--- a/app/spaces/models/__init__.py
+++ b/app/spaces/models/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the models package."""
+
 from .building import Building
 from .room import Room
 

--- a/app/spaces/models/building.py
+++ b/app/spaces/models/building.py
@@ -1,3 +1,5 @@
+"""Building module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/spaces/models/room.py
+++ b/app/spaces/models/room.py
@@ -1,3 +1,5 @@
+"""Room module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/timetable/__init__.py
+++ b/app/timetable/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the timetable package."""

--- a/app/timetable/admin/__init__.py
+++ b/app/timetable/admin/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the admin package."""
+
 from .core import AcademicYearAdmin, SectionAdmin, SemesterAdmin
 from .inlines import SemesterInline, SectionInline, ReservationInline
 from .resources import AcademicYearResource, SectionResource, SemesterResource

--- a/app/timetable/admin/core.py
+++ b/app/timetable/admin/core.py
@@ -1,3 +1,5 @@
+"""Core module."""
+
 # app/admin/academic_admin.py
 from django.contrib import admin
 from guardian.admin import GuardedModelAdmin

--- a/app/timetable/admin/inlines.py
+++ b/app/timetable/admin/inlines.py
@@ -1,3 +1,5 @@
+"""Inlines module."""
+
 from app.timetable.models.reservation import Reservation
 from django.contrib import admin
 

--- a/app/timetable/admin/reservation.py
+++ b/app/timetable/admin/reservation.py
@@ -1,3 +1,5 @@
+"""Reservation module."""
+
 from __future__ import annotations
 
 from django.contrib import admin

--- a/app/timetable/admin/widgets.py
+++ b/app/timetable/admin/widgets.py
@@ -1,3 +1,5 @@
+"""Widgets module."""
+
 from import_export import widgets
 from app.timetable.models import AcademicYear, Semester
 import re

--- a/app/timetable/apps.py
+++ b/app/timetable/apps.py
@@ -1,3 +1,5 @@
+"""Apps module."""
+
 # app/timetable/apps.py
 from django.apps import AppConfig
 

--- a/app/timetable/models/__init__.py
+++ b/app/timetable/models/__init__.py
@@ -1,3 +1,5 @@
+"""Initialization for the models package."""
+
 from .academic_year import AcademicYear
 from .reservation import Reservation
 from .section import Section

--- a/app/timetable/models/academic_year.py
+++ b/app/timetable/models/academic_year.py
@@ -1,3 +1,5 @@
+"""Academic year module."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -1,3 +1,5 @@
+"""Reservation module."""
+
 from decimal import Decimal
 
 from app.finance.models.financial_record import SectionFee

--- a/app/timetable/models/schedule.py
+++ b/app/timetable/models/schedule.py
@@ -1,3 +1,5 @@
+"""Schedule module."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -1,3 +1,5 @@
+"""Section module."""
+
 from __future__ import annotations
 
 from django.core.validators import MinValueValidator

--- a/app/timetable/models/semester.py
+++ b/app/timetable/models/semester.py
@@ -1,3 +1,5 @@
+"""Semester module."""
+
 from __future__ import annotations
 from django.db import models
 from app.shared.enums import SEMESTER_NUMBER

--- a/app/timetable/models/term.py
+++ b/app/timetable/models/term.py
@@ -1,3 +1,5 @@
+"""Term module."""
+
 from __future__ import annotations
 from django.db import models
 

--- a/app/timetable/models/validator.py
+++ b/app/timetable/models/validator.py
@@ -1,3 +1,5 @@
+"""Validator module."""
+
 from django.core.exceptions import ValidationError
 
 from app.shared.constants import MAX_STUDENT_CREDITS

--- a/app/timetable/models/weekly_schedule.py
+++ b/app/timetable/models/weekly_schedule.py
@@ -1,3 +1,5 @@
+"""Weekly schedule module."""
+
 from __future__ import annotations
 from django.db import models
 
@@ -6,7 +8,3 @@ class WeeklySchedule(models.Model):
     dailyschedule = models.ForeignKey(
         DailySchedule, on_delete=models.PROTECT, related_name="dailyschedule"
     )
-
-    
-
-

--- a/app/timetable/services.py
+++ b/app/timetable/services.py
@@ -1,3 +1,5 @@
+"""Services module."""
+
 from __future__ import annotations
 
 from typing import Iterable, List

--- a/app/timetable/signals.py
+++ b/app/timetable/signals.py
@@ -1,3 +1,5 @@
+"""Signals module."""
+
 from django.db import transaction
 from django.db.models import Max
 from django.db.models.signals import pre_save, post_save

--- a/app/timetable/utils.py
+++ b/app/timetable/utils.py
@@ -1,3 +1,5 @@
+"""Utils module."""
+
 from datetime import date
 from typing import Optional
 

--- a/app/views.py
+++ b/app/views.py
@@ -1,0 +1,1 @@
+"""Views module."""

--- a/app/website/__init__.py
+++ b/app/website/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the website package."""

--- a/app/website/admin.py
+++ b/app/website/admin.py
@@ -1,0 +1,1 @@
+"""Admin module."""

--- a/app/website/apps.py
+++ b/app/website/apps.py
@@ -1,3 +1,5 @@
+"""Apps module."""
+
 from django.apps import AppConfig
 
 

--- a/app/website/models.py
+++ b/app/website/models.py
@@ -1,0 +1,1 @@
+"""Models module."""

--- a/app/website/tests.py
+++ b/app/website/tests.py
@@ -1,0 +1,1 @@
+"""Tests module."""

--- a/app/website/urls.py
+++ b/app/website/urls.py
@@ -1,3 +1,5 @@
+"""Urls module."""
+
 from django.urls import path
 from django.views.generic import TemplateView
 

--- a/app/website/views.py
+++ b/app/website/views.py
@@ -1,3 +1,5 @@
+"""Views module."""
+
 from __future__ import annotations
 
 # mypy: ignore-errors

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Initialization for the tests package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
+"""Conftest module."""
+
 import pytest
 from django.contrib.auth import get_user_model
+
 
 @pytest.fixture
 def superuser(db):
     User = get_user_model()
     return User.objects.create_superuser(
-        username="super",
-        email="super@example.com",
-        password="secret123"
+        username="super", email="super@example.com", password="secret123"
     )

--- a/tests/features/test_admin_login.py
+++ b/tests/features/test_admin_login.py
@@ -1,10 +1,13 @@
+"""Test admin login module."""
+
 from pytest_bdd import scenario, given, when, then, parsers
 from django.urls import reverse
 
 
-@scenario('admin_login.feature', 'Superuser logs in successfully')
+@scenario("admin_login.feature", "Superuser logs in successfully")
 def test_admin_login():
     pass
+
 
 @given("I am on the admin login page", target_fixture="response")
 def admin_login_page(client):

--- a/tests/safe.py
+++ b/tests/safe.py
@@ -1,3 +1,5 @@
+"""Safe module."""
+
 from app.shared.constants.roles import DEFAULT_ROLE_TO_COLLEGE, USER_ROLES
 from django.test import SimpleTestCase
 

--- a/tests/test_college_widget.py
+++ b/tests/test_college_widget.py
@@ -1,3 +1,5 @@
+"""Test college widget module."""
+
 from types import SimpleNamespace
 
 import pytest

--- a/tests/test_course_admin.py
+++ b/tests/test_course_admin.py
@@ -1,3 +1,5 @@
+"""Test course admin module."""
+
 import pytest
 from django.contrib.admin.widgets import AutocompleteSelect
 

--- a/tests/test_course_resource.py
+++ b/tests/test_course_resource.py
@@ -1,3 +1,5 @@
+"""Test course resource module."""
+
 import tablib
 import pytest
 

--- a/tests/test_course_widget.py
+++ b/tests/test_course_widget.py
@@ -1,3 +1,5 @@
+"""Test course widget module."""
+
 import pytest
 from django.db.utils import IntegrityError
 
@@ -86,7 +88,9 @@ def test_course_widget_uses_credit_field_and_title_on_create():
 @pytest.mark.django_db
 def test_course_widget_updates_existing_course_title_and_credits():
     col = College.objects.create(code="COAS", fullname="Arts")
-    course = Course.objects.create(name="MATH", number="201", title="Old", college=col, credit_hours=3)
+    course = Course.objects.create(
+        name="MATH", number="201", title="Old", college=col, credit_hours=3
+    )
     cw = CourseWidget(model=Course, field="code")
 
     row = {"college": "COAS", "credit_hours": "4", "course_title": "New"}

--- a/tests/test_curriculum_course.py
+++ b/tests/test_curriculum_course.py
@@ -1,3 +1,5 @@
+"""Test curriculum course module."""
+
 from datetime import date
 
 import pytest

--- a/tests/test_donor_scholarship.py
+++ b/tests/test_donor_scholarship.py
@@ -1,3 +1,5 @@
+"""Test donor scholarship module."""
+
 import pytest
 from datetime import date
 from django.contrib.auth import get_user_model

--- a/tests/test_faculty_helper.py
+++ b/tests/test_faculty_helper.py
@@ -1,3 +1,5 @@
+"""Test faculty helper module."""
+
 import pytest
 from django.contrib.auth.models import User
 

--- a/tests/test_import_schedule.py
+++ b/tests/test_import_schedule.py
@@ -1,3 +1,5 @@
+"""Test import schedule module."""
+
 import io
 import pytest
 from django.core.management import call_command

--- a/tests/test_import_schedule_cmd.py
+++ b/tests/test_import_schedule_cmd.py
@@ -1,3 +1,5 @@
+"""Test import schedule cmd module."""
+
 import io
 import tempfile
 import pytest

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,3 +1,5 @@
+"""Test imports module."""
+
 import pytest
 from django.conf import settings
 from django.apps import apps

--- a/tests/test_populate_sections.py
+++ b/tests/test_populate_sections.py
@@ -1,3 +1,5 @@
+"""Test populate sections module."""
+
 import io
 from types import SimpleNamespace
 

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -1,3 +1,5 @@
+"""Test reservation module."""
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError

--- a/tests/test_room_widget.py
+++ b/tests/test_room_widget.py
@@ -1,3 +1,5 @@
+"""Test room widget module."""
+
 import pytest
 
 from app.spaces.admin.widgets import RoomWidget

--- a/tests/test_section_autoincrement.py
+++ b/tests/test_section_autoincrement.py
@@ -1,3 +1,5 @@
+"""Test section autoincrement module."""
+
 import pytest
 from datetime import date
 

--- a/tests/test_section_widgets.py
+++ b/tests/test_section_widgets.py
@@ -1,3 +1,5 @@
+"""Test section widgets module."""
+
 import pytest
 
 from app.timetable.admin import SectionCodeWidget

--- a/tests/test_shared_utils.py
+++ b/tests/test_shared_utils.py
@@ -1,3 +1,5 @@
+"""Test shared utils module."""
+
 from datetime import date
 
 import pytest

--- a/tests/test_timetable_dates.py
+++ b/tests/test_timetable_dates.py
@@ -1,3 +1,5 @@
+"""Test timetable dates module."""
+
 import pytest
 from datetime import date
 from django.core.exceptions import ValidationError

--- a/tests/test_weekdays_enum.py
+++ b/tests/test_weekdays_enum.py
@@ -1,3 +1,5 @@
+"""Test weekdays enum module."""
+
 from app.shared.enums import WEEKDAYS_NUMBER
 
 


### PR DESCRIPTION
## Summary
- scan `app/` and `tests/` for missing module docstrings
- add minimal docstrings to each Python file

## Testing
- `black app tests --exclude 'app/timetable/admin/resources.py'`
- `flake8 app tests` *(fails: F821 undefined names, F401 unused imports, etc.)*
- `pytest` *(fails: ImportError: cannot import name 'Reservation' from partially initialized module)*

------
https://chatgpt.com/codex/tasks/task_e_683e8fc415cc8323901c773640e29a4b