### PR TITLE
Refactor tests to use fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,3 +102,38 @@ def superuser(db):
     return User.objects.create_superuser(
         username="super", email="super@example.com", password="secret123"
     )
+
+
+# ─── generic factories ------------------------------------------------------
+@pytest.fixture
+def college_factory():
+    """Return helper to create colleges on demand."""
+
+    def _make(code: str = "COAS", fullname: str = "College"):
+        return College.objects.create(code=code, fullname=fullname)
+
+    return _make
+
+
+@pytest.fixture
+def course_factory(college_factory):
+    """Return helper to create courses linked to a college."""
+
+    def _make(
+        name: str = "TEST",
+        number: str = "101",
+        title: str = "Course",
+        credit_hours: int = 3,
+        college=None,
+    ):
+        if college is None:
+            college = college_factory()
+        return Course.objects.create(
+            name=name,
+            number=number,
+            title=title,
+            credit_hours=credit_hours,
+            college=college,
+        )
+
+    return _make

--- a/tests/test_college_widget.py
+++ b/tests/test_college_widget.py
@@ -20,8 +20,8 @@ def test_college_widget_tracks_new_colleges() -> None:
 
 
 @pytest.mark.django_db
-def test_college_widget_skips_existing_colleges():
-    College.objects.create(code="COAS", fullname="Arts")
+def test_college_widget_skips_existing_colleges(college_factory):
+    college_factory(code="COAS", fullname="Arts")
     cw = CollegeWidget(College, "code")
     dummy = SimpleNamespace(_new_colleges=set())
     cw._resource = dummy

--- a/tests/test_course_admin.py
+++ b/tests/test_course_admin.py
@@ -4,36 +4,36 @@ import pytest
 from django.contrib.admin.widgets import AutocompleteSelect
 
 from django.urls import reverse
-from app.academics.models import College, Course
+
 from app.academics.admin.forms import CourseForm
 
 
 @pytest.mark.django_db
-def test_course_form_prefills_single_college():
-    col = College.objects.create(code="ENG", fullname="Engineering")
-    Course.objects.create(name="MAT", number="101", title="Math", college=col)
+def test_course_form_prefills_single_college(college_factory, course_factory):
+    col = college_factory(code="ENG", fullname="Engineering")
+    course_factory(name="MAT", number="101", title="Math", college=col)
     form = CourseForm(data={"name": "MAT", "number": "101", "title": "New"})
     assert form.is_valid()
     assert form.cleaned_data["college"] == col
 
 
 @pytest.mark.django_db
-def test_course_form_autocomplete_multiple_colleges():
-    c1 = College.objects.create(code="ENG", fullname="Engineering")
-    c2 = College.objects.create(code="SCI", fullname="Science")
-    Course.objects.create(name="CSC", number="101", title="Intro", college=c1)
-    Course.objects.create(name="CSC", number="101", title="Other", college=c2)
+def test_course_form_autocomplete_multiple_colleges(college_factory, course_factory):
+    c1 = college_factory(code="ENG", fullname="Engineering")
+    c2 = college_factory(code="SCI", fullname="Science")
+    course_factory(name="CSC", number="101", title="Intro", college=c1)
+    course_factory(name="CSC", number="101", title="Other", college=c2)
     form = CourseForm(data={"name": "CSC", "number": "101", "title": "New"})
     widget = form.fields["college"].widget
     assert isinstance(widget, AutocompleteSelect)
 
 
 @pytest.mark.django_db
-def test_update_course_college_action(client, superuser):
-    old = College.objects.create(code="ENG", fullname="Engineering")
-    new = College.objects.create(code="SCI", fullname="Science")
-    c1 = Course.objects.create(name="PHY", number="101", title="Physics", college=old)
-    c2 = Course.objects.create(name="CHE", number="101", title="Chemistry", college=old)
+def test_update_course_college_action(client, superuser, college_factory, course_factory):
+    old = college_factory(code="ENG", fullname="Engineering")
+    new = college_factory(code="SCI", fullname="Science")
+    c1 = course_factory(name="PHY", number="101", title="Physics", college=old)
+    c2 = course_factory(name="CHE", number="101", title="Chemistry", college=old)
 
     client.force_login(superuser)
     url = reverse("admin:academics_course_changelist")

--- a/tests/test_course_resource.py
+++ b/tests/test_course_resource.py
@@ -4,12 +4,12 @@ import tablib
 import pytest
 
 from app.academics.admin.resources import CourseResource
-from app.academics.models import College, Course
+from app.academics.models import Course
 
 
 @pytest.mark.django_db
-def test_course_import_without_name_number():
-    College.objects.create(code="COAS", fullname="Arts")
+def test_course_import_without_name_number(college):
+    _ = college
     dataset = tablib.Dataset(
         headers=["code", "title", "year", "college", "name", "number"]
     )
@@ -22,8 +22,8 @@ def test_course_import_without_name_number():
 
 
 @pytest.mark.django_db
-def test_course_import_skips_mismatched_rows():
-    College.objects.create(code="COAS", fullname="Arts")
+def test_course_import_skips_mismatched_rows(college):
+    _ = college
     dataset = tablib.Dataset(headers=["code", "name", "number", "title", "college"])
     dataset.append(["MATH101", "MATH", "101", "Calc I", "COAS"])
     dataset.append(["ENG101", "ENG", "201", "Eng", "COAS"])

--- a/tests/test_course_widget.py
+++ b/tests/test_course_widget.py
@@ -9,9 +9,9 @@ from app.shared.enums import CREDIT_NUMBER
 
 
 @pytest.mark.django_db
-def test_course_widget_returns_existing_course():
-    col = College.objects.create(code="COAS", fullname="College of Arts")
-    course = Course.objects.create(name="MATH", number="101", title="Math", college=col)
+def test_course_widget_returns_existing_course(college_factory, course_factory):
+    col = college_factory(code="COAS", fullname="College of Arts")
+    course = course_factory(name="MATH", number="101", title="Math", college=col)
     cw = CourseWidget(model=Course, field="code")
 
     result = cw.clean("MATH101 - COAS", {"college": "COAS"})
@@ -34,8 +34,8 @@ def test_course_widget_creates_missing_course_and_college():
 
 
 @pytest.mark.django_db
-def test_course_widget_defaults_to_row_college():
-    col = College.objects.create(code="COAS", fullname="College of Arts")
+def test_course_widget_defaults_to_row_college(college_factory):
+    col = college_factory(code="COAS", fullname="College of Arts")
     cw = CourseWidget(model=Course, field="code")
 
     course = cw.clean("CHEM100", {"college": "COAS"})
@@ -46,12 +46,12 @@ def test_course_widget_defaults_to_row_college():
 
 
 @pytest.mark.django_db
-def test_course_widget_raises_value_error_with_multiple_matches():
-    col = College.objects.create(code="COAS", fullname="College of Arts")
-    Course.objects.create(name="BIO", number="101", title="Bio I", college=col)
+def test_course_widget_raises_value_error_with_multiple_matches(college_factory, course_factory):
+    col = college_factory(code="COAS", fullname="College of Arts")
+    course_factory(name="BIO", number="101", title="Bio I", college=col)
 
     with pytest.raises(IntegrityError):
-        Course.objects.create(name="BIO", number="101", title="Bio II", college=col)
+        course_factory(name="BIO", number="101", title="Bio II", college=col)
 
     cw = CourseWidget(model=Course, field="code")
 
@@ -60,12 +60,10 @@ def test_course_widget_raises_value_error_with_multiple_matches():
 
 
 @pytest.mark.django_db
-def test_course_widget_token_college_overrides_row_college():
-    row_college = College.objects.create(code="COAS", fullname="College of Arts")
-    token_college = College.objects.create(code="COET", fullname="College of Engineering")
-    course = Course.objects.create(
-        name="MATH", number="101", title="Math", college=token_college
-    )
+def test_course_widget_token_college_overrides_row_college(college_factory, course_factory):
+    row_college = college_factory(code="COAS", fullname="College of Arts")
+    token_college = college_factory(code="COET", fullname="College of Engineering")
+    course = course_factory(name="MATH", number="101", title="Math", college=token_college)
     cw = CourseWidget(model=Course, field="code")
 
     result = cw.clean("MATH101 - COET", {"college": row_college.code})
@@ -86,10 +84,14 @@ def test_course_widget_uses_credit_field_and_title_on_create():
 
 
 @pytest.mark.django_db
-def test_course_widget_updates_existing_course_title_and_credits():
-    col = College.objects.create(code="COAS", fullname="Arts")
-    course = Course.objects.create(
-        name="MATH", number="201", title="Old", college=col, credit_hours=3
+def test_course_widget_updates_existing_course_title_and_credits(college_factory, course_factory):
+    col = college_factory(code="COAS", fullname="Arts")
+    course = course_factory(
+        name="MATH",
+        number="201",
+        title="Old",
+        college=col,
+        credit_hours=3,
     )
     cw = CourseWidget(model=Course, field="code")
 

--- a/tests/test_curriculum_course.py
+++ b/tests/test_curriculum_course.py
@@ -10,10 +10,10 @@ from app.academics.models import College, Course, Curriculum, CurriculumCourse
 
 
 @pytest.mark.django_db
-def test_curriculum_import_sets_year_level():
-    college = College.objects.create(code="COAS", fullname="College of Arts")
-    Course.objects.create(name="BIO", number="101", title="Bio I", college=college)
-    Course.objects.create(name="BIO", number="201", title="Bio II", college=college)
+def test_curriculum_import_sets_year_level(college_factory, course_factory):
+    college = college_factory(code="COAS", fullname="College of Arts")
+    course_factory(name="BIO", number="101", title="Bio I", college=college)
+    course_factory(name="BIO", number="201", title="Bio II", college=college)
 
     data = Dataset(headers=["short_name", "title", "college", "list_courses"])
     data.append(["SCI", "Science", college.code, "BIO101;BIO201"])
@@ -30,8 +30,8 @@ def test_curriculum_import_sets_year_level():
 
 
 @pytest.mark.django_db
-def test_year_level_defaults_from_course_number():
-    college = College.objects.create(
+def test_year_level_defaults_from_course_number(college_factory, course_factory):
+    college = college_factory(
         code="COET",
         fullname="College of Engineering and Technology",
     )
@@ -41,7 +41,7 @@ def test_year_level_defaults_from_course_number():
         college=college,
         creation_date=date.today(),
     )
-    course = Course.objects.create(
+    course = course_factory(
         name="CSC",
         number="201",
         title="Intro",
@@ -58,10 +58,10 @@ def test_year_level_defaults_from_course_number():
 
 
 @pytest.mark.django_db
-def test_curriculum_course_resource_imports_rows():
-    college = College.objects.create(code="COAS", fullname="Arts")
-    Course.objects.create(name="BIO", number="101", title="Bio I", college=college)
-    Course.objects.create(name="BIO", number="201", title="Bio II", college=college)
+def test_curriculum_course_resource_imports_rows(college_factory, course_factory):
+    college = college_factory(code="COAS", fullname="Arts")
+    course_factory(name="BIO", number="101", title="Bio I", college=college)
+    course_factory(name="BIO", number="201", title="Bio II", college=college)
 
     data = Dataset(headers=["curriculum_name", "college", "course"])
     data.append(["SCI", "COAS", "BIO101"])

--- a/tests/test_faculty_helper.py
+++ b/tests/test_faculty_helper.py
@@ -3,14 +3,14 @@
 import pytest
 from django.contrib.auth.models import User
 
-from app.academics.models import College
+
 from app.people.models.profile import _ensure_faculty, FacultyProfile
 from app.shared.constants import TEST_PW
 
 
 @pytest.mark.django_db
-def test_ensure_faculty_creates_user_and_profile():
-    col = College.objects.create(code="COAS", fullname="College of Arts")
+def test_ensure_faculty_creates_user_and_profile(college_factory):
+    col = college_factory(code="COAS", fullname="College of Arts")
 
     prof = _ensure_faculty("Jane Doe", col)
 
@@ -26,8 +26,8 @@ def test_ensure_faculty_creates_user_and_profile():
 
 
 @pytest.mark.django_db
-def test_ensure_faculty_is_idempotent():
-    col = College.objects.create(code="COAS", fullname="College of Arts")
+def test_ensure_faculty_is_idempotent(college_factory):
+    col = college_factory(code="COAS", fullname="College of Arts")
     prof1 = _ensure_faculty("Jane Doe", col)
     prof2 = _ensure_faculty("Jane Doe", col)
 

--- a/tests/test_section_autoincrement.py
+++ b/tests/test_section_autoincrement.py
@@ -1,52 +1,29 @@
 """Test section autoincrement module."""
 
 import pytest
-from datetime import date
 
-from app.academics.models import College, Course
-from app.timetable.models import AcademicYear, Semester, Section
+from app.timetable.models import Section
 
 
 @pytest.mark.django_db
-def test_assigns_1_when_first_section_created():
-    college = College.objects.create(code="COAS", fullname="Arts")
-    course = Course.objects.create(
-        name="MATH", number="101", title="Calculus", college=college
-    )
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester.objects.create(academic_year=ay, number=1)
-
-    section = Section.objects.create(course=course, semester=sem, number=None)
+def test_assigns_1_when_first_section_created(course, semester):
+    section = Section.objects.create(course=course, semester=semester, number=None)
 
     assert section.number == 1
 
 
 @pytest.mark.django_db
-def test_sequential_numbers():
-    college = College.objects.create(code="COAS", fullname="Arts")
-    course = Course.objects.create(
-        name="MATH", number="101", title="Calculus", college=college
-    )
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester.objects.create(academic_year=ay, number=1)
-
-    first = Section.objects.create(course=course, semester=sem, number=None)
-    second = Section.objects.create(course=course, semester=sem, number=None)
+def test_sequential_numbers(course, semester):
+    first = Section.objects.create(course=course, semester=semester, number=None)
+    second = Section.objects.create(course=course, semester=semester, number=None)
 
     assert first.number == 1
     assert second.number == 2
 
 
 @pytest.mark.django_db
-def test_updating_existing_section_does_not_change_number():
-    college = College.objects.create(code="COAS", fullname="Arts")
-    course = Course.objects.create(
-        name="MATH", number="101", title="Calculus", college=college
-    )
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester.objects.create(academic_year=ay, number=1)
-
-    section = Section.objects.create(course=course, semester=sem, number=None)
+def test_updating_existing_section_does_not_change_number(course, semester):
+    section = Section.objects.create(course=course, semester=semester, number=None)
     section.schedule = "MWF"
     section.save()
     section.refresh_from_db()


### PR DESCRIPTION
## Summary
- create `college_factory` and `course_factory` in `conftest.py`
- reuse fixtures in course widget and admin tests
- apply factories in curriculum and faculty tests
- simplify section auto-increment tests
- use college fixture in course resource and college widget tests

## Testing
- `black tests/conftest.py tests/test_course_widget.py tests/test_course_resource.py tests/test_curriculum_course.py tests/test_faculty_helper.py tests/test_section_autoincrement.py tests/test_course_admin.py tests/test_college_widget.py` *(fails: pyenv: black: command not found)*
- `flake8` *(fails: command not found)*
- `mypy` *(fails: command not found)*
- `pytest -q` *(fails: pyenv: pytest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ea0f58e6c83238565be03599a92e8