### PR TITLE
Fix mypy issues in models and views

### DIFF
--- a/app/shared/mixins.py
+++ b/app/shared/mixins.py
@@ -1,12 +1,11 @@
 """Mixins module."""
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional, cast
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.contrib.auth.models import User
-from typing import Optional
 
 from app.shared.constants import STATUS_CHOICES
 
@@ -44,10 +43,12 @@ class StatusableMixin(models.Model):
     # ─── helpers ──────────────────────────────────────────────
     def _add_status(self, status: str, author: Optional[User]) -> StatusHistory:
         """Helper to append a new status entry."""
-        return self.status_history.create(status=status, author=author)
+        return cast(
+            StatusHistory, self.status_history.create(status=status, author=author)
+        )
 
     def current_status(self) -> Optional[StatusHistory]:
-        return self.status_history.first()
+        return cast(Optional[StatusHistory], self.status_history.first())
 
     def set_pending(self, author: Optional[User]) -> StatusHistory:
         return self._add_status("pending", author)

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -16,9 +16,10 @@ from app.shared.constants import (
     StatusReservation,
 )
 from app.shared.mixins import StatusableMixin
-from typing import TYPE_CHECKING:
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from app.people.models import StaffProfile
     from app.timetable.models import CreditLimitValidator, Section
 
 
@@ -124,7 +125,7 @@ class Reservation(StatusableMixin, models.Model):
             current_registrations=F("current_registrations") - 1
         )
 
-    def mark_paid(self, by_user: models.Model) -> None:
+    def mark_paid(self, by_user: "StaffProfile | None") -> None:
         """Record payment and mark reservation as paid."""
 
         if self.status == StatusReservation.PAID:

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -6,6 +6,7 @@ from django.core.validators import MinValueValidator
 from django.db import models
 from .semester import Semester
 from .schedule import Schedule
+from app.spaces.models import Room
 
 
 class Section(models.Model):
@@ -45,6 +46,11 @@ class Section(models.Model):
     @property
     def long_code(self) -> str:
         return f"{self.semester} {self.short_code}"
+
+    @property
+    def room(self) -> Room | None:
+        """Return teaching room associated with this section."""
+        return self.schedule.room
 
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.long_code} | {self.room}"

--- a/app/timetable/services.py
+++ b/app/timetable/services.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import timedelta, timezone
+from datetime import timedelta
+from django.utils import timezone
 from typing import Iterable, List
 
 from django.core.exceptions import ValidationError
@@ -61,7 +62,7 @@ def reserve_sections(
                 student=student,
                 section=sec,
                 status=StatusReservation.REQUESTED,
-                validation_deadline=timezone.now() + timedelta(days=2),
+                validation_dealine=timezone.now() + timedelta(days=2),
             )
             Section.objects.filter(pk=sec.pk).update(
                 current_registrations=F("current_registrations") + 1

--- a/app/timetable/tasks.py
+++ b/app/timetable/tasks.py
@@ -8,7 +8,7 @@ from app.shared.constants import StatusReservation
 def cancel_expired_reservations():
     now = timezone.now()
     expired_reservations = Reservation.objects.filter(
-        status=StatusReservation.REQUESTED, validation_deadline__lt=now
+        status=StatusReservation.REQUESTED, validation_dealine__lt=now
     )
 
     with transaction.atomic():

--- a/app/website/views.py
+++ b/app/website/views.py
@@ -7,6 +7,8 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import F
+from django.contrib.auth.models import User
+from typing import cast
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 
@@ -25,7 +27,8 @@ def landing_page(request: HttpRequest) -> HttpResponse:
 @login_required
 def create_reservation(request: HttpRequest, section_id: int) -> HttpResponseRedirect:
     """Reserve a section for the current student if possible."""
-    student = request.user.profile.studentprofile
+    user = cast(User, request.user)
+    student = user.studentprofile
     section = get_object_or_404(Section, id=section_id)
 
     if Reservation.objects.filter(student=student, section=section).exists():
@@ -57,7 +60,8 @@ def create_reservation(request: HttpRequest, section_id: int) -> HttpResponseRed
 @login_required
 def student_dashboard(request):
     """Display the student's reservations, registrations and fees."""
-    student = request.user.profile.studentprofile
+    user = cast(User, request.user)
+    student = user.studentprofile
 
     if request.method == "POST":
         section_id = request.POST.get("section_id")


### PR DESCRIPTION
## Summary
- add Section.room helper for schedule room
- cast status helper returns in StatusableMixin
- type annotate Reservation.mark_paid
- fix deadline field reference in reservation services and tasks
- use the authenticated user properly in website views

## Testing
- `PYENV_VERSION=3.12.10 black app/ --check`
- `PYENV_VERSION=3.12.10 python -m flake8 app/` *(fails: No module named flake8)*
- `PYENV_VERSION=3.12.10 mypy app/` *(fails: No module named 'mypy_django_plugin')*
- `PYENV_VERSION=3.12.10 pytest -q` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683ef97a7cac8323bc1c9cb548c57878