### PR TITLE
Add documentation for core models and admin classes

### DIFF
--- a/app/academics/admin/core.py
+++ b/app/academics/admin/core.py
@@ -27,6 +27,7 @@ from .resources import (
 
 @admin.register(Course)
 class CourseAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin interface configuration for :class:`~app.academics.models.Course`."""
     resource_class = CourseResource
     list_display = ("code", "title", "credit_hours", "college")
     list_filter = ("curricula__college", "curricula")
@@ -63,6 +64,7 @@ class CourseAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(Prerequisite)
 class PrerequisiteAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin interface for :class:`~app.academics.models.Prerequisite`."""
     resource_class = PrerequisiteResource
     actions = [update_curriculum]
     list_display = ("course", "prerequisite_course", "curriculum")
@@ -73,6 +75,7 @@ class PrerequisiteAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(Curriculum)
 class CurriculumAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin options for :class:`~app.academics.models.Curriculum`."""
     resource_class = CurriculumResource
     # add the action button on the import form
     import_form_class = BulkActionImportForm
@@ -90,6 +93,7 @@ class CurriculumAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(College)
 class CollegeAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin interface for :class:`~app.academics.models.College`."""
     resource_class = CollegeResource
     list_display = ("code", "fullname", "current_dean")
     search_fields = ("code", "fullname")
@@ -97,6 +101,7 @@ class CollegeAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(CurriculumCourse)
 class CurriculumCourseAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin screen for :class:`~app.academics.models.CurriculumCourse`."""
     resource_class = CurriculumCourseResource
     list_display = ("curriculum", "course")
     autocomplete_fields = ("curriculum", "course")

--- a/app/finance/admin/core.py
+++ b/app/finance/admin/core.py
@@ -7,11 +7,13 @@ from app.finance.models import Payment, Scholarship
 
 @admin.register(Payment)
 class PaymentAdmin(admin.ModelAdmin):
+    """Admin settings for :class:`~app.finance.models.Payment`."""
     list_display = ("reservation", "amount", "method", "recorded_by", "created_at")
     readonly_fields = ("created_at",)
 
 
 @admin.register(Scholarship)
 class ScholarshipAdmin(admin.ModelAdmin):
+    """Admin interface for :class:`~app.finance.models.Scholarship`."""
     list_display = ("student", "donor", "amount", "start_date", "end_date")
     autocomplete_fields = ("donor", "student")

--- a/app/people/admin/core.py
+++ b/app/people/admin/core.py
@@ -9,6 +9,7 @@ from app.people.models import DonorProfile, FacultyProfile, StudentProfile
 
 @admin.register(StudentProfile)
 class StudentProfileAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin interface for :class:`~app.people.models.StudentProfile`."""
     list_display = ("student_id", "user", "college", "curriculum")
     search_fields = (
         "student_id",
@@ -24,6 +25,7 @@ class StudentProfileAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(FacultyProfile)
 class FacultyProfileAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin options for :class:`~app.people.models.FacultyProfile`."""
     list_display = ("user", "division", "department", "college", "position")
     search_fields = (
         "user__username",
@@ -40,6 +42,7 @@ class FacultyProfileAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(DonorProfile)
 class DonorProfileAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin management for :class:`~app.people.models.DonorProfile`."""
     list_display = ("user", "donor_id")
     search_fields = (
         "user__username",

--- a/app/spaces/admin/core.py
+++ b/app/spaces/admin/core.py
@@ -11,12 +11,14 @@ from app.spaces.models import Space, Room
 
 @admin.register(Space)
 class SpaceAdmin(GuardedModelAdmin):
+    """Admin management for :class:`~app.spaces.models.Space`."""
     search_fields = ("short_name", "full_name")
     list_display = ("short_name", "full_name")
 
 
 @admin.register(Room)
 class RoomAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin configuration for :class:`~app.spaces.models.Room`."""
     resource_class = RoomResource
     list_display = ("code", "space", "standard_capacity", "exam_capacity")
     search_fields = ("space__short_name", "code")

--- a/app/spaces/models/core.py
+++ b/app/spaces/models/core.py
@@ -28,6 +28,7 @@ class Room(models.Model):
 
     @property
     def full_code(self) -> str:
+        """Full room identifier combining space short name and code."""
         return f"{self.space}-{self.code}"
 
     def __str__(self) -> str:  # pragma: no cover

--- a/app/timetable/admin/core.py
+++ b/app/timetable/admin/core.py
@@ -11,6 +11,7 @@ from .resources import SectionResource, SemesterResource
 
 @admin.register(AcademicYear)
 class AcademicYearAdmin(GuardedModelAdmin):
+    """Admin settings for :class:`~app.timetable.models.AcademicYear`."""
     list_display = ("long_name", "start_date", "short_name")
     date_hierarchy = "start_date"
     inlines = [SemesterInline]
@@ -20,6 +21,7 @@ class AcademicYearAdmin(GuardedModelAdmin):
 
 @admin.register(Semester)
 class SemesterAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin configuration for :class:`~app.timetable.models.Semester`."""
     resource_class = SemesterResource
     list_filter = ("academic_year",)  # needs academic_year her
     autocomplete_fields = ("academic_year",)
@@ -28,6 +30,7 @@ class SemesterAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(Section)
 class SectionAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin interface for :class:`~app.timetable.models.Section`."""
     resource_class = SectionResource
     list_display = ("long_code", "course", "semester", "faculty", "max_seats")
     inlines = [ReservationInline, ScheduleInline]

--- a/app/timetable/admin/reservation.py
+++ b/app/timetable/admin/reservation.py
@@ -9,6 +9,7 @@ from .models import Reservation
 
 @admin.register(Reservation)
 class ReservationAdmin(admin.ModelAdmin):
+    """Admin interface for :class:`~app.timetable.models.Reservation`."""
     list_display = (
         "student",
         "section",


### PR DESCRIPTION
## Summary
- document admin classes for academics, timetable, finance, spaces and people
- document Room.full_code property

## Testing
- `pytest -q` *(fails: pyenv version not installed)*
- `black --check app` *(fails: command not found)*
- `flake8 app` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844984989108323bb109a53ae662bb7