### PR TITLE
Register Schedule admin

### DIFF
--- a/app/timetable/admin/__init__.py
+++ b/app/timetable/admin/__init__.py
@@ -3,6 +3,7 @@
 from .core import AcademicYearAdmin, SectionAdmin, SemesterAdmin
 from .inlines import SemesterInline, SectionInline, ReservationInline
 from .resources import AcademicYearResource, SectionResource, SemesterResource
+from .schedule import ScheduleAdmin
 
 __all__ = [
     "AcademicYearAdmin",
@@ -14,4 +15,5 @@ __all__ = [
     "AcademicYearResource",
     "SemesterResource",
     "ReservationInline",
+    "ScheduleAdmin",
 ]

--- a/app/timetable/admin/schedule.py
+++ b/app/timetable/admin/schedule.py
@@ -1,0 +1,18 @@
+"""Schedule admin module."""
+
+from django.contrib import admin
+from guardian.admin import GuardedModelAdmin
+from import_export.admin import ImportExportModelAdmin
+
+from app.timetable.models.schedule import Schedule
+from .resources import ScheduleResource
+
+
+@admin.register(Schedule)
+class ScheduleAdmin(ImportExportModelAdmin, GuardedModelAdmin):
+    """Admin configuration for :class:`Schedule`."""
+
+    resource_class = ScheduleResource
+    list_display = ("section", "weekday", "start_time", "end_time", "room")
+    list_filter = ("weekday", "room")
+    autocomplete_fields = ("section", "room")


### PR DESCRIPTION
## Summary
- add ScheduleAdmin for schedule records
- export ScheduleAdmin via admin package

## Testing
- `python3 -m black app/timetable/admin/schedule.py app/timetable/admin/__init__.py`
- `flake8 app/timetable/admin/schedule.py app/timetable/admin/__init__.py`
- `python3 -m flake8 app/timetable/admin/schedule.py app/timetable/admin/__init__.py`
- `mypy app/timetable/admin/schedule.py app/timetable/admin/__init__.py`
- `python3 -m mypy app/timetable/admin/schedule.py app/timetable/admin/__init__.py`
- `pytest -q`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68449e0e2d4c8323ab234b3b381474e2