### PR TITLE
Limit curriculum list filter by selected college

### DIFF
--- a/app/academics/admin/filters.py
+++ b/app/academics/admin/filters.py
@@ -1,6 +1,8 @@
 """Filters module."""
 
 from django.contrib import admin
+from django.db.models import Count
+
 from app.academics.models import Curriculum
 
 
@@ -9,7 +11,19 @@ class CurriculumFilter(admin.SimpleListFilter):
     parameter_name = "curriculum"
 
     def lookups(self, request, model_admin):
-        return [(c.pk, c.short_name) for c in Curriculum.objects.all()]
+        qs = model_admin.get_queryset(request)
+        college_id = request.GET.get("college__id__exact")
+        if college_id:
+            qs = qs.filter(college_id=college_id)
+        curricula = (
+            qs.values("curriculum", "curriculum__short_name")
+            .annotate(count=Count("pk"))
+            .filter(curriculum__isnull=False, count__gt=0)
+            .order_by("curriculum__short_name")
+        )
+        return [
+            (c["curriculum"], c["curriculum__short_name"]) for c in curricula
+        ]
 
     def queryset(self, request, qs):
         if self.value():

--- a/app/people/admin/core.py
+++ b/app/people/admin/core.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from guardian.admin import GuardedModelAdmin
 from import_export.admin import ImportExportModelAdmin
 
+from app.academics.admin.filters import CurriculumFilter
 from app.people.models import DonorProfile, FacultyProfile, StudentProfile
 
 
@@ -19,7 +20,7 @@ class StudentProfileAdmin(ImportExportModelAdmin, GuardedModelAdmin):
     )
     # > add an inlines to list the current course of the students = []
     # > add an inlines to list the passed course of the students = []
-    list_filter = ("college", "curriculum")
+    list_filter = ("college", CurriculumFilter)
     autocomplete_fields = ("user", "college", "curriculum")
 
 


### PR DESCRIPTION
## Summary
- apply selected college to CurriculumFilter
- narrow curricula options to those present in current queryset
- use CurriculumFilter in StudentProfile admin

## Testing
- `black app/` *(fails: pyenv: version `tuth' is not installed)*
- `flake8 app/` *(fails: command not found)*
- `mypy app/` *(fails: pyenv: version `tuth' is not installed)*
- `pytest tests/` *(fails: pyenv: version `tuth' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844a50c6b908323bd497f4d7ef39642