### PR TITLE
Add typing hints for import/export modules

### DIFF
--- a/app/shared/management/commands/import_resources.py
+++ b/app/shared/management/commands/import_resources.py
@@ -8,10 +8,10 @@ from django.db import transaction
 from import_export import resources
 from tablib import Dataset
 
-from app.academics.admin.resources import (
+from app.academics.admin.resources import (  # noqa: F401
     CourseResource,
     CurriculumCourseResource,
-)  # noqa: F401
+)
 from app.academics.models.college import College  # noqa: F401
 from app.shared.management.populate_helpers.auth import (  # noqa: F401
     ensure_role_groups,
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         if not path.exists():
             raise FileNotFoundError(str(path))
 
-        dataset = Dataset().load(open(path).read(), format="csv")
+        dataset: Dataset = Dataset().load(open(path).read(), format="csv")
 
         # sanitize column headers: strip whitespace and drop empties
         dataset.headers = [(header or "").strip() for header in dataset.headers]
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         for key, ResourceClass in RESOURCES_MAP:
             resource: resources.ModelResource = ResourceClass()
 
-            validation = resource.import_data(dataset, dry_run=True)
+            validation: resources.Result = resource.import_data(dataset, dry_run=True)
 
             if validation.has_errors():
                 self.stdout.write(self.style.ERROR(f"'{key}': validation errors:"))

--- a/app/spaces/admin/widgets.py
+++ b/app/spaces/admin/widgets.py
@@ -16,7 +16,13 @@ class SpaceWidget(widgets.ForeignKeyWidget):
     def __init__(self):
         super().__init__(Space, field="code")
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(
+        self,
+        value: str | None,
+        row: dict[str, str] | None = None,
+        *args,
+        **kwargs,
+    ) -> Space | None:
 
         if not value:
             return None
@@ -37,7 +43,13 @@ class RoomWidget(widgets.ForeignKeyWidget):
         super().__init__(Room, field="code")
         self.space_w = SpaceWidget()
 
-    def clean(self, value, row=None, *args, **kwargs) -> Space | None:
+    def clean(
+        self,
+        value: str,
+        row: dict[str, str] | None = None,
+        *args,
+        **kwargs,
+    ) -> Room | None:
 
         tba_space, _ = Space.objects.get_or_create(
             code="TBA", defaults={"full_name": "To Be Announced"}
@@ -66,7 +78,13 @@ class RoomCodeWidget(widgets.ForeignKeyWidget):
         super().__init__(Room, field="code")
         self.space_w = SpaceWidget()
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(
+        self,
+        value: str | None,
+        row: dict[str, str] | None = None,
+        *args,
+        **kwargs,
+    ) -> Room | None:
         if not value:
             return None
 

--- a/app/timetable/admin/resources/section.py
+++ b/app/timetable/admin/resources/section.py
@@ -27,7 +27,13 @@ class SectionResource(resources.ModelResource):
         widget=FacultyProfileWidget(),
     )
 
-    def save_instance(self, instance, is_create, row, **kwargs):
+    def save_instance(
+        self,
+        instance: Section,
+        is_create: bool,
+        row: dict[str, str],
+        **kwargs,
+    ) -> None:
         """Wrap save to log errors during import."""
         try:
             return super().save_instance(instance, is_create, row, **kwargs)

--- a/app/timetable/admin/widgets/core.py
+++ b/app/timetable/admin/widgets/core.py
@@ -16,7 +16,13 @@ class AcademicYearCodeWidget(widgets.ForeignKeyWidget):
         super().__init__(AcademicYear, field="code")
         self.ay_pat = re.compile(r"^(\d{2})-(\d{2})$")
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(
+        self,
+        value: str | None,
+        row: dict[str, str] | None = None,
+        *args,
+        **kwargs,
+    ) -> AcademicYear | None:
 
         if not value:
             return None
@@ -50,7 +56,13 @@ class SemesterWidget(widgets.ForeignKeyWidget):
         super().__init__(Semester)  # using pk until start_date can be proven to be uniq
         self.ay_w = AcademicYearCodeWidget()
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(
+        self,
+        value: str | None,
+        row: dict[str, str] | None = None,
+        *args,
+        **kwargs,
+    ) -> Semester | None:
         if not value:
             return None
 
@@ -76,7 +88,13 @@ class SemesterCodeWidget(widgets.ForeignKeyWidget):
         super().__init__(Semester)
         self.sem_pat = re.compile(r"^(?P<year>\d{2}-\d{2})_Sem(?P<num>\d+)$")
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(
+        self,
+        value: str | None,
+        row: dict[str, str] | None = None,
+        *args,
+        **kwargs,
+    ) -> Semester | None:
         if not value:
             return None
 

--- a/app/timetable/admin/widgets/section.py
+++ b/app/timetable/admin/widgets/section.py
@@ -53,7 +53,13 @@ class SectionCodeWidget(widgets.Widget):
         self.sem_code_w = SemesterWidget()
         self.crs_code_w = CourseWidget()
 
-    def clean(self, value, row=None, *args, **kwargs):
+    def clean(
+        self,
+        value: str | None,
+        row: dict[str, str] | None = None,
+        *args,
+        **kwargs,
+    ) -> Section | None:
         if not value:
             return None
 


### PR DESCRIPTION
## Summary
- add explicit return and parameter types on import widgets
- add type hints to import resources command
- fix F401 comment in `import_resources`
- annotate `SectionResource.save_instance`

## Testing
- `flake8 --exclude=.venv,codo-tuth-env`
- `mypy --exclude=.venv app tests` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest -q` *(fails: ImportError: cannot import name 'StaffProfile')*

------
https://chatgpt.com/codex/tasks/task_e_6848519bbcb083238bf20373ac04020f