### PR TITLE
Add tests for SectionResource import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,9 @@ import pytest
 from django.contrib.auth import get_user_model
 
 from app.academics.models import College, Course
-from app.people.models import StaffProfile, StudentProfile
+
+# direct import avoids relying on package re-exports
+from app.people.models.profile import StaffProfile, StudentProfile
 from app.timetable.models import AcademicYear, Session, Section, Semester
 
 User = get_user_model()
@@ -18,7 +20,7 @@ User = get_user_model()
 # ─── reference data ──────────────────────────────────────────────────────────
 @pytest.fixture
 def college():
-    return College.objects.create(code="COAS", fullname="College of Arts and Sciences")
+    return College.objects.create(code="COAS", long_name="College of Arts and Sciences")
 
 
 @pytest.fixture
@@ -110,7 +112,7 @@ def college_factory():
     """Return helper to create colleges on demand."""
 
     def _make(code: str = "COAS", fullname: str = "College"):
-        return College.objects.create(code=code, fullname=fullname)
+        return College.objects.create(code=code, long_name=fullname)
 
     return _make
 

--- a/tests/test_section_resource_import.py
+++ b/tests/test_section_resource_import.py
@@ -1,0 +1,59 @@
+"""Test section resource import module."""
+
+import pytest
+from tablib import Dataset
+
+from app.timetable.admin.resources.section import SectionResource
+from app.timetable.models import Section
+
+
+@pytest.mark.django_db
+def test_import_section_success():
+    """Importing valid data creates a Section."""
+    data = Dataset(
+        headers=[
+            "academic_year",
+            "semester_no",
+            "course_code",
+            "course_no",
+            "college",
+            "section_no",
+            "faculty",
+        ]
+    )
+    data.append(["24-25", "1", "MATH", "101", "COAS", "1", "Dr Jane Doe"])
+
+    resource = SectionResource()
+    result = resource.import_data(data, dry_run=False)
+
+    assert not result.has_errors()
+    section = Section.objects.get()
+    assert section.number == 1
+    assert section.course.code == "MATH101"
+    assert section.semester.number == 1
+    assert section.semester.academic_year.code == "24-25"
+    assert section.faculty.user.first_name == "Jane"
+
+
+@pytest.mark.django_db
+def test_import_section_missing_number_reports_error():
+    """Missing required fields should raise validation errors."""
+    data = Dataset(
+        headers=[
+            "academic_year",
+            "semester_no",
+            "course_code",
+            "course_no",
+            "college_code",
+            "section_no",
+            "faculty",
+        ]
+    )
+    # blank section_no triggers validation failure
+    data.append(["24-25", "1", "MATH", "101", "COAS", "", "Dr Jane Doe"])
+
+    resource = SectionResource()
+    result = resource.import_data(data, dry_run=False)
+
+    assert result.has_errors()
+    assert Section.objects.count() == 0


### PR DESCRIPTION
## Summary
- test SectionResource import workflow
- update fixtures to use `long_name` and direct model imports

## Testing
- `pytest tests/test_section_resource_import.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.spaces.models.building')*

------
https://chatgpt.com/codex/tasks/task_e_68487b08d94c8323bb9a8cbd9a17060f