### PR TITLE
Factor timetable date helpers

### DIFF
--- a/app/spaces/models/__init__.py
+++ b/app/spaces/models/__init__.py
@@ -2,7 +2,11 @@
 
 from .core import Space, Room
 
+# Backwards compatibility alias
+Location = Space
+
 __all__ = [
     "Room",
     "Space",
+    "Location",
 ]

--- a/tests/test_timetable_dates.py
+++ b/tests/test_timetable_dates.py
@@ -6,32 +6,65 @@ from django.core.exceptions import ValidationError
 from app.timetable.models import AcademicYear, Semester, Term
 
 
+def make_semester(
+    ay_start: date,
+    sem_start: date,
+    sem_end: date,
+    sem_number: int = 1,
+    *,
+    year: AcademicYear | None = None,
+) -> tuple[AcademicYear, Semester]:
+    """Return (year, semester) helper."""
+
+    ay = year or AcademicYear.objects.create(start_date=ay_start)
+    sem = Semester.objects.create(
+        academic_year=ay,
+        number=sem_number,
+        start_date=sem_start,
+        end_date=sem_end,
+    )
+    return ay, sem
+
+
+def make_term(
+    sem: Semester, start: date, end: date, number: int = 1, *, persist: bool = False
+) -> Term:
+    """Return a term instance bound to ``sem``."""
+
+    term = Term(
+        semester=sem,
+        number=number,
+        start_date=start,
+        end_date=end,
+    )
+    if persist:
+        term.save()
+    return term
+
+
 @pytest.mark.django_db
 def test_semester_identical_start_end():
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester(
-        academic_year=ay,
-        number=1,
-        start_date=date(2024, 8, 15),
-        end_date=date(2024, 8, 15),
+    ay, sem = make_semester(
+        date(2024, 8, 1),
+        date(2024, 8, 15),
+        date(2024, 8, 15),
     )
     sem.clean()
 
 
 @pytest.mark.django_db
 def test_semester_overlap():
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    Semester.objects.create(
-        academic_year=ay,
-        number=1,
-        start_date=date(2024, 8, 1),
-        end_date=date(2025, 1, 1),
+    ay, _ = make_semester(
+        date(2024, 8, 1),
+        date(2024, 8, 1),
+        date(2025, 1, 1),
     )
-    sem = Semester(
-        academic_year=ay,
-        number=2,
-        start_date=date(2024, 12, 15),
-        end_date=date(2025, 4, 1),
+    _, sem = make_semester(
+        date(2024, 8, 1),
+        date(2024, 12, 15),
+        date(2025, 4, 1),
+        sem_number=2,
+        year=ay,
     )
     with pytest.raises(ValidationError):
         sem.clean()
@@ -39,12 +72,10 @@ def test_semester_overlap():
 
 @pytest.mark.django_db
 def test_semester_out_of_range():
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester(
-        academic_year=ay,
-        number=1,
-        start_date=date(2025, 8, 1),
-        end_date=date(2025, 9, 1),
+    ay, sem = make_semester(
+        date(2024, 8, 1),
+        date(2025, 8, 1),
+        date(2025, 9, 1),
     )
     with pytest.raises(ValidationError):
         sem.clean()
@@ -52,103 +83,73 @@ def test_semester_out_of_range():
 
 @pytest.mark.django_db
 def test_semester_gap_allowed():
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    Semester.objects.create(
-        academic_year=ay,
-        number=1,
-        start_date=date(2024, 8, 1),
-        end_date=date(2024, 12, 31),
+    ay, _ = make_semester(
+        date(2024, 8, 1),
+        date(2024, 8, 1),
+        date(2024, 12, 31),
     )
-    sem = Semester(
-        academic_year=ay,
-        number=2,
-        start_date=date(2025, 1, 15),
-        end_date=date(2025, 4, 30),
+    _, sem = make_semester(
+        date(2024, 8, 1),
+        date(2025, 1, 15),
+        date(2025, 4, 30),
+        sem_number=2,
+        year=ay,
     )
     sem.clean()
 
 
 @pytest.mark.django_db
 def test_term_overlap():
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester.objects.create(
-        academic_year=ay,
-        number=1,
-        start_date=date(2024, 8, 1),
-        end_date=date(2024, 12, 31),
+    ay, sem = make_semester(
+        date(2024, 8, 1),
+        date(2024, 8, 1),
+        date(2024, 12, 31),
     )
-    Term.objects.create(
-        semester=sem,
-        number=1,
-        start_date=date(2024, 8, 1),
-        end_date=date(2024, 10, 1),
-    )
-    term = Term(
-        semester=sem,
-        number=2,
-        start_date=date(2024, 9, 15),
-        end_date=date(2024, 11, 1),
-    )
+    make_term(sem, date(2024, 8, 1), date(2024, 10, 1), persist=True)
+    term = make_term(sem, date(2024, 9, 15), date(2024, 11, 1), number=2)
     with pytest.raises(ValidationError):
         term.clean()
 
 
 @pytest.mark.django_db
 def test_term_out_of_range():
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester.objects.create(
-        academic_year=ay,
-        number=1,
-        start_date=date(2024, 8, 1),
-        end_date=date(2024, 12, 31),
+    ay, sem = make_semester(
+        date(2024, 8, 1),
+        date(2024, 8, 1),
+        date(2024, 12, 31),
     )
-    term = Term(
-        semester=sem,
-        number=1,
-        start_date=date(2025, 1, 1),
-        end_date=date(2025, 1, 10),
-    )
+    term = make_term(sem, date(2025, 1, 1), date(2025, 1, 10))
     with pytest.raises(ValidationError):
         term.clean()
 
 
 @pytest.mark.django_db
 def test_term_gap_allowed():
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester.objects.create(
-        academic_year=ay,
-        number=1,
-        start_date=date(2024, 8, 1),
-        end_date=date(2024, 12, 31),
+    ay, sem = make_semester(
+        date(2024, 8, 1),
+        date(2024, 8, 1),
+        date(2024, 12, 31),
     )
-    Term.objects.create(
-        semester=sem,
-        number=1,
-        start_date=date(2024, 8, 1),
-        end_date=date(2024, 9, 1),
-    )
-    term = Term(
-        semester=sem,
+    make_term(sem, date(2024, 8, 1), date(2024, 9, 1), persist=True)
+    term = make_term(
+        sem,
+        date(2024, 9, 15),
+        date(2024, 10, 1),
         number=2,
-        start_date=date(2024, 9, 15),
-        end_date=date(2024, 10, 1),
     )
     term.clean()
 
 
 @pytest.mark.django_db
 def test_term_identical_start_end():
-    ay = AcademicYear.objects.create(start_date=date(2024, 8, 1))
-    sem = Semester.objects.create(
-        academic_year=ay,
-        number=1,
-        start_date=date(2024, 8, 1),
-        end_date=date(2024, 12, 31),
+    ay, sem = make_semester(
+        date(2024, 8, 1),
+        date(2024, 8, 1),
+        date(2024, 12, 31),
     )
-    term = Term(
-        semester=sem,
-        number=1,
-        start_date=date(2024, 9, 1),
-        end_date=date(2024, 9, 1),
+    term = make_term(
+        sem,
+        date(2024, 9, 1),
+        date(2024, 9, 1),
     )
     term.clean()


### PR DESCRIPTION
## Summary
- alias `Location` to `Space` in spaces models
- factor repeated timetable date setup into helper functions

## Testing
- `python -m pytest tests/test_timetable_dates.py -q`
- `python -m pytest -q` *(fails: ImportError: cannot import name 'populate_sections_from_csv')*

------
https://chatgpt.com/codex/tasks/task_e_684b22416058832392bd82886ab90f2d