### PR TITLE
Extend safe test

### DIFF
--- a/tests/safe.py
+++ b/tests/safe.py
@@ -1,10 +1,32 @@
-"""Safe module."""
+"""Checks invariants for role/college defaults."""
 
-from app.shared.constants.roles import DEFAULT_ROLE_TO_COLLEGE, USER_ROLES
 from django.test import SimpleTestCase
+
+from app.shared.constants.perms import DEFAULT_ROLE_TO_COLLEGE
+
+USER_ROLES = [
+    "dean",
+    "chair",
+    "lecturer",
+    "assistant_professor",
+    "associate_professor",
+    "professor",
+    "technician",
+    "lab_technician",
+    "faculty",
+]
 
 
 class RoleMappingTest(SimpleTestCase):
-    def test_mapping_is_consistent(self):
-        # 1. No duplicate values in the literal  ➜  already true
+    def test_mapping_is_consistent(self) -> None:
+        """Ensure the default mapping stays aligned with ``USER_ROLES``."""
+
+        # No duplicated keys in the mapping
         self.assertEqual(len(DEFAULT_ROLE_TO_COLLEGE), len(set(DEFAULT_ROLE_TO_COLLEGE)))
+
+        # Every expected role has an entry
+        for role in USER_ROLES:
+            self.assertIn(role, DEFAULT_ROLE_TO_COLLEGE)
+
+        # Mapping does not contain unexpected roles
+        self.assertEqual(set(USER_ROLES), set(DEFAULT_ROLE_TO_COLLEGE))


### PR DESCRIPTION
## Summary
- expand role mapping checks for constant coverage

## Testing
- `pytest -k RoleMappingTest tests/safe.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_684cc2571ad48323a2f688fc1842bc8b