### PR TITLE
Add module documentation

### DIFF
--- a/app/finance/utils.py
+++ b/app/finance/utils.py
@@ -1,4 +1,4 @@
-"""Utils module."""
+"""Utility helpers used in the finance app."""
 
 from decimal import Decimal
 
@@ -6,5 +6,18 @@ from app.shared.constants import TUITION_RATE_PER_CREDIT
 
 
 def tuition_for(course, credit_hours: int) -> Decimal:
-    """Return tuition amount for a course."""
+    """Calculate the tuition amount for a course.
+
+    Parameters
+    ----------
+    course
+        The course instance for which tuition is calculated.
+    credit_hours : int
+        Number of credit hours to bill.
+
+    Returns
+    -------
+    Decimal
+        The total tuition cost.
+    """
     return Decimal(credit_hours) * TUITION_RATE_PER_CREDIT

--- a/app/shared/forms.py
+++ b/app/shared/forms.py
@@ -1,4 +1,4 @@
-"""Forms module."""
+"""Utility forms shared across the project."""
 
 from django import forms
 from django.core.exceptions import FieldDoesNotExist
@@ -8,8 +8,10 @@ from .mixins import StatusHistory
 
 
 class StatusHistoryForm(forms.ModelForm):
-    """
-    limite the choice to those allowed for the model
+    """ModelForm for creating status history records.
+
+    The form limits the ``state`` choices to those defined on the related
+    model so only valid transitions are offered.
     """
 
     class Meta:
@@ -17,6 +19,14 @@ class StatusHistoryForm(forms.ModelForm):
         fields = ["state", "author"]
 
     def __init__(self, *args, **kwargs):
+        """Initialize the form and adjust state choices.
+
+        Parameters
+        ----------
+        *args, **kwargs
+            Standard Django ``ModelForm`` arguments.
+        """
+
         super().__init__(*args, **kwargs)
         content_type = self.initial.get("content_type") or getattr(
             self.instance, "content_type", None

--- a/app/shared/management/populate_helpers/auth.py
+++ b/app/shared/management/populate_helpers/auth.py
@@ -1,4 +1,4 @@
-"""Auth module."""
+"""Helpers to create demo users and roles during data population."""
 
 from app.shared.constants.perms import UserRole
 from django.contrib.auth.models import Group, User
@@ -14,6 +14,8 @@ from .utils import log
 
 
 def ensure_superuser(cmd: BaseCommand) -> None:
+    """Recreate the default development superuser."""
+
     su = dict(username="dev", email="dev@tu.koba.sarl", password="dev")
     User.objects.filter(username=su["username"]).delete()
     User.objects.create_superuser(**su)
@@ -21,6 +23,8 @@ def ensure_superuser(cmd: BaseCommand) -> None:
 
 
 def ensure_role_groups() -> Dict[str, Group]:
+    """Create missing ``Group`` objects for each user role."""
+
     return {
         role: Group.objects.get_or_create(name=role.capitalize())[0]
         for role, label in UserRole
@@ -30,6 +34,8 @@ def ensure_role_groups() -> Dict[str, Group]:
 def upsert_test_users_and_roles(
     cmd: BaseCommand, colleges: Dict[str, College], groups: Dict[str, Group]
 ) -> None:
+    """Create test users for each role and associate default colleges."""
+
     for role, _ in UserRole:
         user, _ = User.objects.get_or_create(username=f"test_{role}")
         user.is_staff = True

--- a/app/shared/management/populate_helpers/perms.py
+++ b/app/shared/management/populate_helpers/perms.py
@@ -1,4 +1,4 @@
-"""Perms module."""
+"""Helpers to grant permissions during initial data population."""
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
@@ -13,6 +13,7 @@ from app.shared.constants import OBJECT_PERM_MATRIX, MODEL_APP
 
 
 def grant_model_level_perms(groups):
+    """Assign model-level permissions to the provided groups."""
     for model, perms in OBJECT_PERM_MATRIX.items():
         try:
             ct = ContentType.objects.get(app_label=MODEL_APP[model], model=model)
@@ -28,6 +29,7 @@ def grant_model_level_perms(groups):
 
 
 def grant_college_object_perms():
+    """Grant object-level college permissions to role assignments."""
     for ra in RoleAssignment.objects.select_related("college"):
         if ra.college is None:
             continue

--- a/app/shared/management/populate_helpers/sections.py
+++ b/app/shared/management/populate_helpers/sections.py
@@ -10,10 +10,17 @@ from __future__ import annotations
 
 
 def parse_int(value: str | None) -> int | None:
-    """Return ``int(value)`` when possible.
+    """Safely convert a string to ``int``.
 
-    Handles numbers represented as ``"1.0"`` or ``"1"`` and ignores
-    non-numeric strings by returning ``None``.
+    Parameters
+    ----------
+    value : str | None
+        Raw numeric value possibly containing trailing decimals.
+
+    Returns
+    -------
+    int | None
+        The integer representation or ``None`` if conversion fails.
     """
 
     if value is None:

--- a/app/shared/management/populate_helpers/utils.py
+++ b/app/shared/management/populate_helpers/utils.py
@@ -1,4 +1,4 @@
-"""Utils module."""
+"""Utility helpers for management commands."""
 
 from django.core.management.base import BaseCommand
 
@@ -6,5 +6,7 @@ from app.shared.constants import STYLE_DEFAULT
 
 
 def log(cmd: BaseCommand, msg: str, style: str = STYLE_DEFAULT) -> None:
+    """Write a styled message to the command output."""
+
     style_obj = getattr(cmd.style, style, cmd.style.NOTICE)
     cmd.stdout.write(style_obj(msg))

--- a/app/shared/utils.py
+++ b/app/shared/utils.py
@@ -1,4 +1,4 @@
-"""Utils module."""
+"""General utility helpers shared between apps."""
 
 from typing import Mapping, Optional, Tuple
 
@@ -10,11 +10,21 @@ from app.shared.constants import COURSE_PATTERN
 def expand_course_code(
     code: str, *, row: Optional[Mapping[str, str]] = None, default_college: str = "COAS"
 ) -> Tuple[str, str, str]:
-    """Return (dept_code, course_num, college_code) from ``code``.
+    """Parse a course code into its components.
 
-    ``code`` may optionally include the college after a dash.  If missing,
-    ``row['college']`` is used when available, otherwise ``default_college``.
-    ``row`` is the raw CSV row passed during imports.
+    Parameters
+    ----------
+    code : str
+        Raw course code such as ``"AGR121-CFAS"``.
+    row : Mapping[str, str] | None, optional
+        Optional CSV row providing a ``college_code`` fallback.
+    default_college : str, optional
+        College code to use when none is provided. Defaults to ``"COAS"``.
+
+    Returns
+    -------
+    tuple[str, str, str]
+        The department code, course number and college code.
     """
 
     assert "/" not in code
@@ -32,6 +42,21 @@ def expand_course_code(
 
 
 def make_course_code(name: str, number: str, college: str | None = None) -> str:
-    """Compact representation used internally to identify a course."""
+    """Return a compact code from name, number and optional college.
+
+    Parameters
+    ----------
+    name : str
+        Department code.
+    number : str
+        Course number.
+    college : str | None, optional
+        College code to include in the resulting string.
+
+    Returns
+    -------
+    str
+        A normalized course identifier.
+    """
     cc = "" if college is None else f"-{college}"
     return f"{name}{number}{cc}".upper()

--- a/app/timetable/services.py
+++ b/app/timetable/services.py
@@ -1,4 +1,4 @@
-"""Services module."""
+"""Business logic helpers for the timetable app."""
 
 from __future__ import annotations
 
@@ -16,9 +16,24 @@ from app.timetable.models import Reservation, Section
 
 
 def reserve_sections(student: Student, sections: Iterable[Section]) -> List[Reservation]:
-    """Create reservation objects for ``student`` on each section.
+    """Reserve a set of sections for a student.
 
-    All checks are performed beforehand so the operation is atomic.
+    Parameters
+    ----------
+    student : Student
+        The student requesting the reservations.
+    sections : Iterable[Section]
+        Sections to be reserved.
+
+    Returns
+    -------
+    list[Reservation]
+        The newly created reservation objects.
+
+    Raises
+    ------
+    ValidationError
+        If capacity or credit constraints are violated.
     """
     section_list = list(sections)
 

--- a/app/timetable/utils.py
+++ b/app/timetable/utils.py
@@ -1,4 +1,4 @@
-"""Utils module."""
+"""Utility helpers for the timetable app."""
 
 from datetime import date
 from typing import Optional
@@ -17,14 +17,25 @@ def validate_subperiod(
     overlap_message: str = "Overlapping periods.",
     label: str = "period",
 ) -> None:
-    """
-    Generic date-range validator.
+    """Validate that a child period fits within its container.
 
-    - chronology (start ≤ end)
-    - fully inside its container dates (yes. borders included)
-    - no overlap with siblings (pass the queryset already filtered on parent)
+    Parameters
+    ----------
+    sub_start, sub_end : date | None
+        Start and end dates of the sub period.
+    container_start, container_end : date
+        Bounds of the parent period.
+    overlap_qs : QuerySet | None, optional
+        Sibling queryset to check for overlaps.
+    overlap_message : str, optional
+        Error message for overlapping periods.
+    label : str, optional
+        Field name used in the error dict.
 
-    Raise ``ValidationError`` on failure.
+    Raises
+    ------
+    ValidationError
+        If the period is invalid or overlaps with an existing one.
     """
     # chronological order -----------------------------------------------------
     if sub_start and sub_end and sub_end < sub_start:


### PR DESCRIPTION
## Summary
- document admin forms
- expand helper docs for services, utils, and populate scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cc262789c832396632bcf58b6d5ee