### PR TITLE
Add unit tests and helper stubs

### DIFF
--- a/app/shared/management/populate_helpers/sections.py
+++ b/app/shared/management/populate_helpers/sections.py
@@ -24,3 +24,53 @@ def parse_int(value: str | None) -> int | None:
         return int(float(token))
     except ValueError:
         return None
+
+import csv
+from datetime import date
+from app.academics.models import College, Course
+from app.timetable.models import AcademicYear, Semester, Section, Session
+
+
+def populate_sections_from_csv(cmd, csv_stream) -> None:
+    """Create Sections and related objects from a CSV stream."""
+    reader = csv.DictReader(csv_stream)
+    for row in reader:
+        college_code = row.get("college", "").strip()
+        course_code = row.get("course", "").strip()
+        semester_code = row.get("semester", "").strip()
+        number = parse_int(row.get("number")) or 1
+        instructor_id = parse_int(row.get("instructor"))
+        room_id = parse_int(row.get("room"))
+        max_seats = parse_int(row.get("max_seats")) or 30
+
+        college, _ = College.objects.get_or_create(
+            code=college_code, defaults={"long_name": college_code}
+        )
+        dept = "".join(c for c in course_code if c.isalpha())
+        num = "".join(c for c in course_code if c.isdigit())
+        course, _ = Course.objects.get_or_create(
+            name=dept,
+            number=num,
+            defaults={"title": dept, "college": college, "code": f"{dept}{num}"},
+        )
+
+        year_part, sem_part = semester_code.split("_Sem")
+        start_year = 2000 + int(year_part.split("-")[0])
+        ay, _ = AcademicYear.objects.get_or_create(start_date=date(start_year, 1, 1))
+        semester, _ = Semester.objects.get_or_create(
+            academic_year=ay,
+            number=int(sem_part),
+            defaults={"start_date": ay.start_date, "end_date": ay.start_date},
+        )
+
+        section = Section.objects.create(
+            semester=semester,
+            course=course,
+            number=number,
+            faculty_id=instructor_id,
+            start_date=semester.start_date,
+            end_date=semester.end_date,
+            max_seats=max_seats,
+        )
+        if room_id:
+            Session.objects.create(section=section, room_id=room_id)

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -57,6 +57,18 @@ class Section(models.Model):
     def long_code(self) -> str:
         return f"{self.semester} {self.short_code}"
 
+    # compatibility aliases -------------------------------------------------
+    @property
+    def instructor_id(self):
+        """Return the associated faculty id."""
+        return self.faculty_id
+
+    @property
+    def room_id(self):
+        """Return the room id of the first session if any."""
+        first = self.sessions.first()
+        return first.room_id if first else None
+
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.long_code} | {self.space_codes}"
 

--- a/tests/test_course_level.py
+++ b/tests/test_course_level.py
@@ -1,0 +1,17 @@
+"""Test Course.level property."""
+
+import pytest
+
+from app.academics.models import Course
+
+
+@pytest.mark.django_db
+def test_course_level_valid(course_factory, college_factory):
+    course = course_factory(number="201", college=college_factory())
+    assert course.level == "sophomore"
+
+
+@pytest.mark.django_db
+def test_course_level_invalid(course_factory, college_factory):
+    course = course_factory(number="999", college=college_factory())
+    assert course.level == "other"

--- a/tests/test_effective_credit_hours.py
+++ b/tests/test_effective_credit_hours.py
@@ -1,0 +1,31 @@
+"""Test CurriculumCourse.effective_credit_hours."""
+
+import pytest
+
+from app.academics.models import Curriculum, CurriculumCourse
+
+
+@pytest.mark.django_db
+def test_effective_credit_hours_override(course_factory, college_factory):
+    college = college_factory()
+    curriculum = Curriculum.objects.create(short_name="SCI", college=college)
+    course = course_factory(college=college, credit_hours=3)
+    cc = CurriculumCourse.objects.create(
+        curriculum=curriculum,
+        course=course,
+        credit_hours=4,
+    )
+    assert cc.effective_credit_hours == 4
+
+
+@pytest.mark.django_db
+def test_effective_credit_hours_fallback(course_factory, college_factory):
+    college = college_factory()
+    curriculum = Curriculum.objects.create(short_name="SCI", college=college)
+    course = course_factory(college=college, credit_hours=3)
+    cc = CurriculumCourse.objects.create(
+        curriculum=curriculum,
+        course=course,
+        credit_hours=None,
+    )
+    assert cc.effective_credit_hours == 3

--- a/tests/test_make_course_code.py
+++ b/tests/test_make_course_code.py
@@ -1,0 +1,11 @@
+"""Test make_course_code utility."""
+
+from app.shared.utils import make_course_code
+
+
+def test_make_course_code_without_college():
+    assert make_course_code("mat", "101") == "MAT101"
+
+
+def test_make_course_code_with_college():
+    assert make_course_code("mat", "101", "COET") == "MAT101-COET"

--- a/tests/test_parse_int.py
+++ b/tests/test_parse_int.py
@@ -1,0 +1,17 @@
+"""Test parse_int utility."""
+
+import pytest
+
+from app.shared.management.populate_helpers.sections import parse_int
+
+
+def test_parse_int_numeric_values():
+    assert parse_int("42") == 42
+    assert parse_int("1.0") == 1
+    assert parse_int(" 3.5 ") == 3
+
+
+def test_parse_int_non_numeric_values():
+    assert parse_int(None) is None
+    assert parse_int("abc") is None
+    assert parse_int("") is None

--- a/tests/test_section_availability.py
+++ b/tests/test_section_availability.py
@@ -1,0 +1,16 @@
+"""Test Section.has_available_seats method."""
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_has_available_seats_true(section_factory):
+    section = section_factory(1)
+    assert section.has_available_seats()
+
+
+@pytest.mark.django_db
+def test_has_available_seats_false(section_factory):
+    section = section_factory(1)
+    section.current_registrations = section.max_seats
+    assert not section.has_available_seats()

--- a/tests/test_validate_subperiod.py
+++ b/tests/test_validate_subperiod.py
@@ -1,0 +1,42 @@
+"""Test validate_subperiod helper."""
+
+from datetime import timedelta
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from app.timetable.models import Term
+from app.timetable.utils import validate_subperiod
+
+
+@pytest.mark.django_db
+def test_validate_subperiod_overlap(semester):
+    Term.objects.create(
+        semester=semester,
+        number=1,
+        start_date=semester.start_date,
+        end_date=semester.start_date + timedelta(days=30),
+    )
+
+    with pytest.raises(ValidationError):
+        validate_subperiod(
+            sub_start=semester.start_date + timedelta(days=15),
+            sub_end=semester.start_date + timedelta(days=45),
+            container_start=semester.start_date,
+            container_end=semester.end_date,
+            overlap_qs=Term.objects.filter(semester=semester),
+            overlap_message="overlap",
+            label="term",
+        )
+
+
+@pytest.mark.django_db
+def test_validate_subperiod_out_of_range(semester):
+    with pytest.raises(ValidationError):
+        validate_subperiod(
+            sub_start=semester.start_date - timedelta(days=1),
+            sub_end=semester.start_date + timedelta(days=5),
+            container_start=semester.start_date,
+            container_end=semester.end_date,
+            label="term",
+        )


### PR DESCRIPTION
## Summary
- create new unit tests for several helper functions and methods
- expose compatibility aliases on `Section`
- add `_ensure_faculty` helper for tests
- implement `populate_sections_from_csv` used in tests

## Testing
- `codo-tuth-env/bin/python -m pytest -q` *(fails: 38 failed, 50 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684cc2a713088323af111b6bc056cd9d