### PR TITLE
Add docstrings for constants and models

### DIFF
--- a/app/academics/models/college.py
+++ b/app/academics/models/college.py
@@ -48,6 +48,7 @@ class College(models.Model):
         return f"{self.code}"
 
     def clean(self) -> None:
+        """Validate that ``code`` and ``long_name`` refer to the same entry."""
         if self.code and self.long_name:
             if self.code != self.long_name:
                 raise ValidationError(
@@ -55,5 +56,6 @@ class College(models.Model):
                 )
 
     def save(self, *args, **kwargs):
+        """Ensure ``long_name`` matches the selected ``code`` before saving."""
         self.long_name = CollegeLongNameChoices[self.code]
         super().save(*args, **kwargs)

--- a/app/academics/models/concentration.py
+++ b/app/academics/models/concentration.py
@@ -6,7 +6,7 @@ from django.db import models
 
 
 class Concentration(models.Model):
-    """Optional major for a curriculum."""
+    """Optional specialization that further narrows a curriculum."""
 
     # revoir
     name = models.CharField(max_length=255)
@@ -23,4 +23,5 @@ class Concentration(models.Model):
     # )
 
     def __str__(self) -> str:  # pragma: no cover
+        """Return the name and associated curriculum."""
         return f"{self.name} ({self.curriculum})"

--- a/app/academics/models/course.py
+++ b/app/academics/models/course.py
@@ -10,7 +10,7 @@ from app.academics.models.curriculum import Curriculum
 
 
 class Course(models.Model):
-    """Catalog entry defining a unit of instruction."""
+    """University catalogue entry describing a single course offering."""
 
     code = models.CharField(max_length=20, editable=False)
     # > need to change it and everywhere with course_dept
@@ -58,13 +58,12 @@ class Course(models.Model):
 
     # ---------- hooks ----------
     def save(self, *args, **kwargs) -> None:
-        """
-        updating course_code on the fly
-        """
+        """Populate ``code`` from ``name`` and ``number`` before saving."""
         self.code = make_course_code(name=self.name, number=self.number)
         super().save(*args, **kwargs)
 
     def __str__(self) -> str:  # pragma: no cover
+        """Return the ``CODE - Title`` representation."""
         return f"{self.code} - {self.title}"
 
     class Meta:

--- a/app/academics/models/curriculum.py
+++ b/app/academics/models/curriculum.py
@@ -10,7 +10,7 @@ from app.shared.mixins import StatusableMixin
 
 
 class Curriculum(StatusableMixin, models.Model):
-    """Academic programme offered by a College."""
+    """Set of courses that make up a degree programme within a college."""
 
     short_name = models.CharField(max_length=40)
     long_name = models.CharField(max_length=255, blank=True, null=True)
@@ -36,6 +36,7 @@ class Curriculum(StatusableMixin, models.Model):
     )
 
     def __str__(self) -> str:  # pragma: no cover
+        """Return the curriculum short name."""
         return f"{self.short_name}"
 
     def clean(self) -> None:

--- a/app/academics/models/curriculum_course.py
+++ b/app/academics/models/curriculum_course.py
@@ -8,9 +8,7 @@ from app.shared.enums import CREDIT_NUMBER
 
 
 class CurriculumCourse(models.Model):
-    """
-    Junction table between Curriculum and Course.
-    """
+    """Map :class:`Curriculum` instances to their constituent courses."""
 
     curriculum = models.ForeignKey(
         "academics.Curriculum", on_delete=models.CASCADE, related_name="programme_lines"
@@ -41,9 +39,11 @@ class CurriculumCourse(models.Model):
         )
 
     def __str__(self) -> str:  # pragma: no cover
+        """Return ``Curriculum <-> Course`` for readability."""
         return f"{self.curriculum} <-> {self.course}"
 
     def save(self, *args, **kwargs) -> None:
+        """Default ``credit_hours`` to the course value when unset."""
         if self.credit_hours is None:
             self.credit_hours = self.course.credit_hours
 

--- a/app/finance/models/financial_record.py
+++ b/app/finance/models/financial_record.py
@@ -28,6 +28,8 @@ class FinancialRecord(models.Model):
 
 
 class SectionFee(models.Model):
+    """Additional fee charged for a specific course section."""
+
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)
     fee_type = models.CharField(max_length=50, choices=FeeType.choices)
     amount = models.DecimalField(max_digits=10, decimal_places=2)

--- a/app/finance/models/payment.py
+++ b/app/finance/models/payment.py
@@ -17,4 +17,5 @@ class Payment(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self) -> str:  # pragma: no cover
+        """Return a concise representation of the payment."""
         return f"{self.reservation} - {self.amount}"

--- a/app/finance/models/scholarship.py
+++ b/app/finance/models/scholarship.py
@@ -24,4 +24,5 @@ class Scholarship(models.Model):
     conditions = models.TextField(blank=True)
 
     def __str__(self) -> str:  # pragma: no cover
+        """Return ``"donor -> student"`` for readability in admin screens."""
         return f"{self.donor} -> {self.student}"

--- a/app/registry/models/grade.py
+++ b/app/registry/models/grade.py
@@ -1,7 +1,11 @@
+"""Grade records for completed course sections."""
+
 from django.db import models
 
 
 class Grade(models.Model):
+    """Letter/numeric grade awarded to a student for a Section."""
+
     student = models.ForeignKey("people.Student", on_delete=models.CASCADE)
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)
     letter_grade = models.CharField(max_length=2)  # A+, A, B, etc.
@@ -11,5 +15,6 @@ class Grade(models.Model):
     class Meta:
         unique_together = ("student", "section")
 
-    def __str__(self):
+    def __str__(self) -> str:  # pragma: no cover
+        """Human readable representation used in admin lists."""
         return f"{self.student} – {self.section}: {self.letter_grade}"

--- a/app/shared/constants/__init__.py
+++ b/app/shared/constants/__init__.py
@@ -1,4 +1,4 @@
-"""Initialization for the constants package."""
+"""Expose shared constants and enumerations used throughout the project."""
 
 from itertools import chain
 from typing import List, Tuple

--- a/app/shared/constants/academics.py
+++ b/app/shared/constants/academics.py
@@ -1,4 +1,10 @@
-"""Academics module."""
+"""Constants used by the :mod:`academics` app.
+
+This module centralizes enumerations and patterns used when working with
+academic entities such as :class:`~app.academics.models.Course` or
+curricula. It exposes the ``COURSE_PATTERN`` regular expression, maximum
+credit load for a student and enumerations for colleges and curriculum
+statuses."""
 
 from django.db import models
 import re

--- a/app/shared/constants/curriculum.py
+++ b/app/shared/constants/curriculum.py
@@ -1,4 +1,8 @@
-"""Curriculum module."""
+"""Sample curriculum data used in development and tests.
+
+``TEST_ENVIRONMENTAL_STUDIES_CURRICULUM`` provides a ready-made list of
+course tuples that can be loaded to quickly seed a Curriculum instance
+for experiments or unit tests."""
 
 # code should absolutely be 6 char long, else will fail.
 TEST_ENVIRONMENTAL_STUDIES_CURRICULUM = [

--- a/app/shared/constants/finance.py
+++ b/app/shared/constants/finance.py
@@ -1,4 +1,9 @@
-"""Finance module."""
+"""Constants for the :mod:`finance` app.
+
+This module defines enumerations representing various aspects of the
+financial domain such as payment methods, fee types and student
+clearance statuses.  It also exposes the ``TUITION_RATE_PER_CREDIT``
+value used when computing tuition."""
 
 from decimal import Decimal
 from django.db import models

--- a/app/shared/constants/perms.py
+++ b/app/shared/constants/perms.py
@@ -1,4 +1,9 @@
-"""Perms module."""
+"""Authorization related constants.
+
+The objects defined here power the role based access control system.
+``OBJECT_PERM_MATRIX`` maps model names and operations to the roles
+allowed to perform them. ``DEFAULT_ROLE_TO_COLLEGE`` and ``MODEL_APP``
+help the permissions middleware resolve context information."""
 
 from django.db import models
 

--- a/app/shared/constants/registry.py
+++ b/app/shared/constants/registry.py
@@ -1,4 +1,7 @@
-"""Registry module."""
+"""Constants used by the student registry subsystem.
+
+This module enumerates document types that can be uploaded by students as
+well as the possible statuses for both registrations and documents."""
 
 from django.db import models
 

--- a/app/shared/constants/timetable.py
+++ b/app/shared/constants/timetable.py
@@ -1,4 +1,7 @@
-"""Timetable module."""
+"""Constants for scheduling and reservations.
+
+Currently this includes the :class:`StatusReservation` enumeration used to
+track the life cycle of a student's reservation of a section."""
 
 from django.db import models
 

--- a/app/timetable/models/academic_year.py
+++ b/app/timetable/models/academic_year.py
@@ -18,6 +18,7 @@ class AcademicYear(models.Model):
     end_date = models.DateField(unique=True)
 
     def clean(self) -> None:
+        """Ensure start and end dates form a valid academic year."""
         if self.start_date.month not in (7, 8, 9, 10):
             raise ValidationError("Start date must be in July–October.")
         if self.start_date:
@@ -25,6 +26,7 @@ class AcademicYear(models.Model):
                 assert self.end_date.year > self.start_date.year
 
     def save(self, *args, **kwargs) -> None:
+        """Populate derived fields ``long_name`` and ``code`` before saving."""
 
         # setting a default for the end_year
         ys = self.start_date.year

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -56,9 +56,11 @@ class Reservation(StatusableMixin, models.Model):
         return tuition_fee + additional_fees
 
     def __str__(self) -> str:
+        """Return ``student -> section (status)``."""
         return f"{self.student} -> {self.section} ({self.status})"
 
     def _check_credit_limit(self) -> None:
+        """Internal helper raising ``ValidationError`` if credit limit exceeded."""
         prospective = self.credit_hours() + self.section.course.credit_hours
         if prospective > MAX_STUDENT_CREDITS:
             raise ValidationError(
@@ -101,6 +103,7 @@ class Reservation(StatusableMixin, models.Model):
         CreditLimitValidator()(self)
 
     def save(self, *args, **kwargs) -> None:
+        """Persist the reservation without extra side effects."""
         super().save(*args, **kwargs)
 
     # ------------------------------------------------------------------
@@ -117,6 +120,7 @@ class Reservation(StatusableMixin, models.Model):
         self.save(update_fields=["status", "date_validated"])
 
     def cancel(self) -> None:
+        """Cancel the reservation and free a seat in the section."""
         assert (
             self.status != StatusReservation.CANCELLED
         ), "Reservation already cancelled."

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -51,13 +51,16 @@ class Section(models.Model):
 
     @property
     def short_code(self) -> str:
+        """Shorthand used for slugging the section in URLs or logs."""
         return f"{self.course.code}:s{self.number}"
 
     @property
     def long_code(self) -> str:
+        """Combine semester code and ``short_code`` for uniqueness."""
         return f"{self.semester} {self.short_code}"
 
     def __str__(self) -> str:  # pragma: no cover
+        """Return a human readable identifier with allocated rooms."""
         return f"{self.long_code} | {self.space_codes}"
 
     def has_available_seats(self) -> bool:

--- a/app/timetable/models/session.py
+++ b/app/timetable/models/session.py
@@ -16,6 +16,7 @@ class Schedule(models.Model):
     end_time = models.TimeField(null=True, blank=True)
 
     def __str__(self):
+        """Return ``weekday: start-end`` for quick inspection in admin."""
         # can we shorten weekday to only have the first 3 char?
         return f"{self.weekday}: {self.start_time}-{self.end_time}"
 
@@ -29,10 +30,12 @@ class Schedule(models.Model):
 
     @property
     def start_time_str(self) -> str:
+        """Start time formatted as ``HH:MM``."""
         return self.start_time.strftime("%H:%M")
 
     @property
     def end_time_str(self) -> str:
+        """End time formatted as ``HH:MM`` or empty string."""
         return self.end_time.strftime("%H:%M") if self.end_time else ""
 
     # > validation end_time should alway be bigger than start_time
@@ -71,17 +74,21 @@ class Session(models.Model):
 
     @property
     def weekday(self):
+        """Shortcut to the schedule's weekday."""
         return self.schedule.weekday if self.schedule else ""
 
     @property
     def start_time(self):
+        """Shortcut to the schedule's starting time."""
         return self.schedule.start_time if self.schedule else ""
 
     @property
     def end_time(self):
+        """Shortcut to the schedule's ending time."""
         return self.schedule.end_time if self.schedule else ""
 
     def __str__(self):
+        """Return ``Schedule, Room`` for use in admin lists."""
         return f"{self.schedule}, {self.room}"
 
     class Meta:

--- a/app/timetable/models/term.py
+++ b/app/timetable/models/term.py
@@ -20,6 +20,7 @@ class Term(models.Model):
     end_date = models.DateField(null=True, blank=True)
 
     def clean(self) -> None:
+        """Validate dates are inside the parent semester and do not overlap."""
         container_start = self.semester.start_date
         container_end = self.semester.end_date
         assert container_start is not None and container_end is not None

--- a/app/timetable/models/validator.py
+++ b/app/timetable/models/validator.py
@@ -14,6 +14,7 @@ class CreditLimitValidator:
     """Ensure a student's reservation doesn't exceed the credit limit."""
 
     def __call__(self, reservation: "Reservation") -> None:
+        """Raise ``ValidationError`` if ``reservation`` exceeds max credits."""
         # compute the hours the student would have if this reservation succeeds
         prospective = reservation.credit_hours() + reservation.section.course.credit_hours
         if prospective > MAX_STUDENT_CREDITS:


### PR DESCRIPTION
## Summary
- explain constants in module docstrings
- clarify models with better docstrings
- document methods and properties across apps

## Testing
- `black app/shared/constants app/registry/models/grade.py app/finance/models app/academics/models app/timetable/models`
- `flake8 app/shared/constants app/registry/models/grade.py app/finance/models app/academics/models app/timetable/models` *(fails: config parsing error)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684cc2ae5b188323a50379706d8108a6