### PR TITLE
Implement PaymentHistory string rep

### DIFF
--- a/app/finance/admin/core.py
+++ b/app/finance/admin/core.py
@@ -2,15 +2,24 @@
 
 from django.contrib import admin
 
-from app.finance.models import Payment, Scholarship
+from app.finance.models import Payment, PaymentHistory, Scholarship
 
 
 @admin.register(Payment)
 class PaymentAdmin(admin.ModelAdmin):
     """Admin settings for :class:`~app.finance.models.Payment`."""
 
-    list_display = ("reservation", "amount", "method", "recorded_by", "created_at")
+    # Use Payment.__str__ for readability in list views
+    list_display = ("__str__", "reservation", "method", "recorded_by")
     readonly_fields = ("created_at",)
+
+
+@admin.register(PaymentHistory)
+class PaymentHistoryAdmin(admin.ModelAdmin):
+    """Admin interface for :class:`~app.finance.models.PaymentHistory`."""
+
+    # Shows summary string plus related info
+    list_display = ("__str__", "financial_record", "method", "recorded_by")
 
 
 @admin.register(Scholarship)

--- a/app/finance/models/payment_history.py
+++ b/app/finance/models/payment_history.py
@@ -20,3 +20,7 @@ class PaymentHistory(models.Model):
         on_delete=models.SET_NULL,
         related_name="payments_recorded",
     )
+
+    def __str__(self) -> str:  # pragma: no cover
+        """Return "<amount> on <date>" for admin readability."""
+        return f"{self.amount} on {self.payment_date.date()}"

--- a/tests/test_payment_history.py
+++ b/tests/test_payment_history.py
@@ -1,0 +1,12 @@
+import pytest
+from decimal import Decimal
+from app.finance.models import FinancialRecord, PaymentHistory
+
+
+@pytest.mark.django_db
+def test_payment_history_str(student_profile, staff_profile):
+    fr = FinancialRecord.objects.create(student=student_profile, total_due=Decimal("0"))
+    ph = PaymentHistory.objects.create(
+        financial_record=fr, amount=Decimal("25.00"), recorded_by=staff_profile
+    )
+    assert str(ph) == f"{ph.amount} on {ph.payment_date.date()}"


### PR DESCRIPTION
## Summary
- show `<amount> on <date>` for PaymentHistory
- display concise representation in finance admin
- test the PaymentHistory string format

## Testing
- `python3 -m flake8 app/finance/admin/core.py app/finance/models/payment_history.py tests/test_payment_history.py --max-line-length=90 --per-file-ignores='__init__.py:F401'`
- `python3 -m mypy app/finance/admin/core.py app/finance/models/payment_history.py tests/test_payment_history.py` *(fails: Error importing plugin "mypy_django_plugin.main")*
- `pytest -q tests/test_payment_history.py`

------
https://chatgpt.com/codex/tasks/task_e_68517dc0e53c8323ac8d616291c5cbd9