### PR TITLE
Add Schedule.clean() tests

### DIFF
--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,22 @@
+"""Test Schedule model."""
+
+from datetime import time
+
+import pytest
+
+from app.timetable.models.session import Schedule
+
+
+@pytest.mark.django_db
+def test_schedule_invalid_times():
+    """clean() should assert when end_time precedes start_time."""
+    sched = Schedule(weekday=1, start_time=time(10, 0), end_time=time(9, 0))
+    with pytest.raises(AssertionError, match="start_time must be before end_time"):
+        sched.clean()
+
+
+@pytest.mark.django_db
+def test_schedule_valid_times():
+    """clean() succeeds when times are ordered correctly."""
+    sched = Schedule(weekday=1, start_time=time(8, 0), end_time=time(9, 0))
+    sched.clean()


### PR DESCRIPTION
## Summary
- add a test module for `Schedule.clean`
- check invalid time range errors and a passing case

## Testing
- `python3 -m pytest tests/test_schedule.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3d4878a48323811b00220ac9436b