### PR TITLE
Add validate_subperiod tests

### DIFF
--- a/app/timetable/tests/test_validate_subperiod.py
+++ b/app/timetable/tests/test_validate_subperiod.py
@@ -1,0 +1,88 @@
+import pytest
+from datetime import date
+from django.core.exceptions import ValidationError
+
+from app.timetable.utils import validate_subperiod
+from app.timetable.models import AcademicYear, Semester, Term
+
+
+@pytest.mark.django_db
+def test_valid_subperiod_inside_container():
+    ay = AcademicYear.objects.create(start_date=date(2025, 9, 1))
+    sem = Semester.objects.create(
+        academic_year=ay,
+        number=1,
+        start_date=ay.start_date,
+        end_date=date(2026, 1, 15),
+    )
+    validate_subperiod(
+        sub_start=date(2025, 9, 10),
+        sub_end=date(2025, 10, 10),
+        container_start=sem.start_date,
+        container_end=sem.end_date,
+    )
+
+
+@pytest.mark.django_db
+def test_subperiod_end_before_start_raises():
+    ay = AcademicYear.objects.create(start_date=date(2025, 9, 1))
+    sem = Semester.objects.create(
+        academic_year=ay,
+        number=1,
+        start_date=ay.start_date,
+        end_date=date(2026, 1, 15),
+    )
+    with pytest.raises(ValidationError):
+        validate_subperiod(
+            sub_start=date(2025, 10, 10),
+            sub_end=date(2025, 9, 10),
+            container_start=sem.start_date,
+            container_end=sem.end_date,
+        )
+
+
+@pytest.mark.django_db
+def test_subperiod_outside_container_raises():
+    ay = AcademicYear.objects.create(start_date=date(2025, 9, 1))
+    sem = Semester.objects.create(
+        academic_year=ay,
+        number=1,
+        start_date=ay.start_date,
+        end_date=date(2026, 1, 15),
+    )
+    with pytest.raises(ValidationError):
+        validate_subperiod(
+            sub_start=date(2025, 8, 31),
+            sub_end=date(2025, 9, 10),
+            container_start=sem.start_date,
+            container_end=sem.end_date,
+        )
+
+
+@pytest.mark.django_db
+def test_overlapping_subperiod_raises():
+    ay = AcademicYear.objects.create(start_date=date(2025, 9, 1))
+    sem = Semester.objects.create(
+        academic_year=ay,
+        number=1,
+        start_date=ay.start_date,
+        end_date=date(2026, 1, 15),
+    )
+    Term.objects.create(
+        semester=sem,
+        number=1,
+        start_date=date(2025, 9, 1),
+        end_date=date(2025, 9, 30),
+    )
+
+    with pytest.raises(ValidationError):
+        validate_subperiod(
+            sub_start=date(2025, 9, 15),
+            sub_end=date(2025, 10, 15),
+            container_start=sem.start_date,
+            container_end=sem.end_date,
+            overlap_qs=Term.objects.filter(semester=sem),
+        )
+
+
+

--- a/app/website/tests.py
+++ b/app/website/tests.py
@@ -1,1 +1,0 @@
-"""Tests module."""


### PR DESCRIPTION
## Summary
- remove unused website test placeholder
- add tests for `validate_subperiod` utility

## Testing
- `pytest app/timetable/tests/test_validate_subperiod.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e2faa7fc8323b80b6017eecbad2d