### PR TITLE
fix shared utils college code lookup

### DIFF
--- a/app/shared/tests/test_shared_utils.py
+++ b/app/shared/tests/test_shared_utils.py
@@ -6,12 +6,14 @@ from app.shared.utils import expand_course_code
 
 
 def test_expand_code_explicit_college():
-    result = expand_course_code("MATH101 - COET", row={"college": "COAS"})
+    result = expand_course_code("MATH101 - COET", row={"college_code": "COAS"})
     assert result == ("MATH", "101", "COET")
 
 
 def test_expand_code_defaults_to_row_college():
-    dept, num, college = expand_course_code("CHEM100", row={"college": "COAS"})
+    dept, num, college = expand_course_code(
+        "CHEM100", row={"college_code": "COAS"}
+    )
     assert (dept, num, college) == ("CHEM", "100", "COAS")
 
 

--- a/app/shared/utils.py
+++ b/app/shared/utils.py
@@ -17,7 +17,9 @@ def expand_course_code(
     code : str
         Raw course code such as ``"AGR121-CFAS"``.
     row : Mapping[str, str] | None, optional
-        Optional CSV row providing a ``college_code`` fallback.
+        Optional CSV row providing a ``college_code`` fallback. The
+        ``college_code`` value is used only when the course code itself
+        does not include a college segment.
     default_college : str, optional
         College code to use when none is provided. Defaults to ``"COAS"``.
 
@@ -32,11 +34,17 @@ def expand_course_code(
     match = COURSE_PATTERN.search(code.strip().upper())
     assert match is not None, f"Code '{code}' doesn't match expected pattern"
 
-    dept, num, college = match.group("dept"), match.group("num"), match.group("college")
-    if row and "college_code" in row:
-        college = row["college_code"]
-    else:
-        college = default_college
+    dept, num, college = (
+        match.group("dept"),
+        match.group("num"),
+        match.group("college"),
+    )
+
+    if not college:
+        if row and "college_code" in row:
+            college = row["college_code"]
+        else:
+            college = default_college
 
     return dept, num, college
 


### PR DESCRIPTION
## Summary
- avoid overriding explicit college code in `expand_course_code`
- document `college_code` fallback behavior
- update tests to use `college_code`

## Testing
- `./codo-tuth-env/bin/pytest app/shared/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e3652da483239b6c362390f50931