### PR TITLE
Add docstrings for timetable tasks

### DIFF
--- a/app/timetable/tasks.py
+++ b/app/timetable/tasks.py
@@ -1,3 +1,9 @@
+"""Background tasks for the timetable application.
+
+This module houses operations that are typically run in the background,
+such as periodic cleanup of expired reservations.
+"""
+
 from django.utils import timezone
 from django.db import transaction
 from django.db.models import F
@@ -6,6 +12,13 @@ from app.shared.constants import StatusReservation
 
 
 def cancel_expired_reservations():
+    """Cancel reservations that were not validated before their deadline.
+
+    Reservations past their validation deadline are marked as cancelled.
+    Updates to reservation and section records occur inside a database
+    transaction to keep counts consistent.
+    """
+
     now = timezone.now()
     expired_reservations = Reservation.objects.filter(
         status=StatusReservation.REQUESTED, validation_deadline__lt=now


### PR DESCRIPTION
## Summary
- document the purpose of the timetable tasks module
- explain the automatic cancellation routine

## Testing
- `pytest app/shared/tests app/finance/tests app/people/tests tests/safe.py tests/features/test_admin_login.py -q` *(fails: ModuleNotFoundError: No module named 'app.shared.constants.roles')*

------
https://chatgpt.com/codex/tasks/task_e_6851e3c139408323b22abd493240fa84