### PR TITLE
Add missing docstrings for import commands

### DIFF
--- a/app/shared/management/commands/import_resources.py
+++ b/app/shared/management/commands/import_resources.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""Import multiple resources from a single CSV file.
+
+This command reads a consolidated CSV export containing data for various
+models such as faculty, rooms and timetable elements. It ensures a superuser
+account exists and then creates or updates database records via the admin
+resources for each model.
+"""
+
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +42,8 @@ class Command(BaseCommand):
     help = "Import resources from a CSV file"
 
     def add_arguments(self, parser: CommandParser) -> None:
+        """Register ``--file_path`` CLI option for the CSV to import."""
+
         parser.add_argument(
             "-f",
             "--file_path",
@@ -43,12 +53,14 @@ class Command(BaseCommand):
         )
 
     def clean_column_headers(self, dataset):
-        """filter any blank column headers that may appear due to trailing commas"""
+        """Strip blank headers that may appear due to trailing commas."""
         # sanitize column headers: strip whitespace and drop empties
         dataset.headers = [(header or "").strip() for header in dataset.headers]
         return dataset
 
     def handle(self, *args: Any, **options: Any) -> None:
+        """Validate and import each resource from the provided CSV."""
+
         ensure_superuser(self)
 
         path = Path(options["file_path"])

--- a/app/shared/management/commands/import_resources_individualy.py
+++ b/app/shared/management/commands/import_resources_individualy.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+"""Import resources from per-model CSV files located in a directory.
+
+Each file is mapped to a ``ModelResource`` class used for validation and
+insertion. Running this command requires a superuser and results in database
+records being created or updated for each resource type found.
+"""
+
 from pathlib import Path
 from typing import Any, Tuple
 
@@ -81,6 +88,8 @@ class Command(BaseCommand):
 
     # ------------------------------------------------------------------ args
     def add_arguments(self, parser: CommandParser) -> None:
+        """Add the ``--dir`` option pointing to the directory of CSV files."""
+
         parser.add_argument(
             "-d",
             "--dir",
@@ -90,6 +99,8 @@ class Command(BaseCommand):
 
     # ---------------------------------------------------------------- handle
     def handle(self, *args: Any, **opts: Any) -> None:
+        """Execute the import for every known CSV file in the directory."""
+
         ensure_superuser(self)
 
         base_path: Path = Path(opts["dir"]).expanduser().resolve()


### PR DESCRIPTION
## Summary
- document what the bulk import command does
- document the per-file import command
- clarify CLI arguments and handlers

## Testing
- `pytest tests/features/test_admin_login.py::test_admin_login -q` *(fails: Database access not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6851e3ca5fa483238808f487ad3ad7f9