### PR TITLE
Add usage examples in model docs

### DIFF
--- a/app/academics/models/college.py
+++ b/app/academics/models/college.py
@@ -9,7 +9,18 @@ from app.shared.constants.academics import CollegeCodeChoices, CollegeLongNameCh
 
 
 class College(models.Model):
-    """Institutional unit responsible for a set of programmes."""
+    """Institutional unit responsible for a set of programmes.
+
+    Example:
+        >>> from app.academics.models import College
+        >>> College.objects.create(
+        ...     code="COAS",
+        ...     long_name="College of Arts and Sciences",
+        ... )
+
+    Side Effects:
+        ``save()`` sets ``long_name`` based on ``code``.
+    """
 
     # there should be no constraint here as the VPA may need to
     # rework the name of the colleges from time to time.

--- a/app/academics/models/concentration.py
+++ b/app/academics/models/concentration.py
@@ -6,7 +6,13 @@ from django.db import models
 
 
 class Concentration(models.Model):
-    """Optional specialization that further narrows a curriculum."""
+    """Optional specialization that further narrows a curriculum.
+
+    Example:
+        >>> from app.academics.models import Concentration, Curriculum
+        >>> curriculum = Curriculum.objects.first()
+        >>> Concentration.objects.create(name="Statistics", curriculum=curriculum)
+    """
 
     # revoir
     name = models.CharField(max_length=255)

--- a/app/academics/models/course.py
+++ b/app/academics/models/course.py
@@ -10,7 +10,16 @@ from app.academics.models.curriculum import Curriculum
 
 
 class Course(models.Model):
-    """University catalogue entry describing a single course offering."""
+    """University catalogue entry describing a single course offering.
+
+    Example:
+        >>> from app.academics.models import Course, College
+        >>> coas = College.objects.create(code="COAS", long_name="College of Arts and Sciences")
+        >>> Course.objects.create(name="MATH", number="101", title="Algebra", college=coas)
+
+    Side Effects:
+        ``save()`` populates ``code`` from ``name`` and ``number``.
+    """
 
     code = models.CharField(max_length=20, editable=False)
     # > need to change it and everywhere with course_dept

--- a/app/academics/models/curriculum.py
+++ b/app/academics/models/curriculum.py
@@ -10,7 +10,16 @@ from app.shared.mixins import StatusableMixin
 
 
 class Curriculum(StatusableMixin, models.Model):
-    """Set of courses that make up a degree programme within a college."""
+    """Set of courses that make up a degree programme within a college.
+
+    Example:
+        >>> from app.academics.models import Curriculum, College
+        >>> col = College.objects.create(code="COAS", long_name="Arts and Sciences")
+        >>> Curriculum.objects.create(short_name="BSCS", college=col)
+
+    Side Effects:
+        Status changes update ``is_active`` via signals.
+    """
 
     short_name = models.CharField(max_length=40)
     long_name = models.CharField(max_length=255, blank=True, null=True)

--- a/app/academics/models/curriculum_course.py
+++ b/app/academics/models/curriculum_course.py
@@ -8,7 +8,15 @@ from app.shared.enums import CREDIT_NUMBER
 
 
 class CurriculumCourse(models.Model):
-    """Map :class:`Curriculum` instances to their constituent courses."""
+    """Map :class:`Curriculum` instances to their constituent courses.
+
+    Example:
+        >>> from app.academics.models import CurriculumCourse
+        >>> CurriculumCourse.objects.create(curriculum=curriculum, course=course)
+
+    Side Effects:
+        ``save()`` defaults ``credit_hours`` to the course value when missing.
+    """
 
     curriculum = models.ForeignKey(
         "academics.Curriculum", on_delete=models.CASCADE, related_name="programme_lines"

--- a/app/academics/models/department.py
+++ b/app/academics/models/department.py
@@ -6,7 +6,13 @@ from django.db import models
 
 
 class Department(models.Model):
-    """Academic department belonging to a college."""
+    """Academic department belonging to a college.
+
+    Example:
+        >>> from app.academics.models import Department, College
+        >>> coas = College.objects.create(code="COAS", long_name="College of Arts and Sciences")
+        >>> Department.objects.create(code="MATH", college=coas)
+    """
 
     code = models.CharField(max_length=50, unique=True)
     full_name = models.CharField(max_length=128, blank=True)

--- a/app/academics/models/prerequisite.py
+++ b/app/academics/models/prerequisite.py
@@ -7,7 +7,15 @@ from django.db import models
 
 
 class Prerequisite(models.Model):
-    """Relationship describing that one course must precede another."""
+    """Relationship describing that one course must precede another.
+
+    Example:
+        >>> from app.academics.models import Prerequisite
+        >>> Prerequisite.objects.create(course=course, prerequisite_course=other_course)
+
+    Side Effects:
+        ``clean()`` prevents circular dependencies.
+    """
 
     course = models.ForeignKey(
         "academics.Course", related_name="course_prereq_edges", on_delete=models.CASCADE

--- a/app/finance/models/financial_record.py
+++ b/app/finance/models/financial_record.py
@@ -8,7 +8,12 @@ from app.shared.constants.finance import FeeType, StatusClearance
 
 
 class FinancialRecord(models.Model):
-    """Aggregate balance for a student."""
+    """Aggregate balance for a student.
+
+    Example:
+        >>> from app.finance.models import FinancialRecord
+        >>> FinancialRecord.objects.create(student=student, total_due=0)
+    """
 
     student = models.OneToOneField("people.Student", on_delete=models.CASCADE)
     total_due = models.DecimalField(max_digits=10, decimal_places=2)
@@ -28,7 +33,12 @@ class FinancialRecord(models.Model):
 
 
 class SectionFee(models.Model):
-    """Additional fee charged for a specific course section."""
+    """Additional fee charged for a specific course section.
+
+    Example:
+        >>> from app.finance.models import SectionFee
+        >>> SectionFee.objects.create(section=section, fee_type="lab", amount=20)
+    """
 
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)
     fee_type = models.CharField(max_length=50, choices=FeeType.choices)

--- a/app/finance/models/payment.py
+++ b/app/finance/models/payment.py
@@ -8,7 +8,12 @@ from app.shared.constants import PaymentMethod
 
 
 class Payment(models.Model):
-    """Payment made for a reservation."""
+    """Payment made for a reservation.
+
+    Example:
+        >>> from app.finance.models import Payment
+        >>> Payment.objects.create(reservation=reservation, amount=50, method=PaymentMethod.CASH)
+    """
 
     reservation = models.OneToOneField("timetable.Reservation", on_delete=models.CASCADE)
     amount = models.DecimalField(max_digits=8, decimal_places=2)

--- a/app/finance/models/payment_history.py
+++ b/app/finance/models/payment_history.py
@@ -6,7 +6,12 @@ from django.db import models
 
 
 class PaymentHistory(models.Model):
-    """Individual payment made toward a financial record."""
+    """Individual payment made toward a financial record.
+
+    Example:
+        >>> from app.finance.models import PaymentHistory
+        >>> PaymentHistory.objects.create(financial_record=record, amount=25)
+    """
 
     financial_record = models.ForeignKey(
         "finance.FinancialRecord", related_name="payments", on_delete=models.CASCADE

--- a/app/finance/models/scholarship.py
+++ b/app/finance/models/scholarship.py
@@ -6,7 +6,12 @@ from django.db import models
 
 
 class Scholarship(models.Model):
-    """Financial aid linking a donor to a student."""
+    """Financial aid linking a donor to a student.
+
+    Example:
+        >>> from app.finance.models import Scholarship
+        >>> Scholarship.objects.create(donor=donor, student=student, amount=100)
+    """
 
     donor = models.ForeignKey(
         "people.Donor",

--- a/app/people/models/core.py
+++ b/app/people/models/core.py
@@ -21,7 +21,20 @@ def photo_upload_to(instance: "AbstractPerson", filename: str) -> str:
     return str(Path("photos") / _class / str(instance.user_id) / filename)
 
 
+
 class AbstractPerson(StatusableMixin, models.Model):
+    """Base fields shared by student and staff profiles.
+
+    Example:
+        >>> from django.contrib.auth import get_user_model
+        >>> User = get_user_model()
+        >>> user = User.objects.create(username="john")
+        >>> from app.people.models.others import Student
+        >>> Student.objects.create(user=user, student_id="S1", enrollment_semester=semester)
+
+    Side Effects:
+        ``save()`` assigns an ID derived from ``user``.
+    """
 
     ID_FIELD: str | None = None
     ID_PREFIX: str = "TU_"

--- a/app/people/models/others.py
+++ b/app/people/models/others.py
@@ -11,7 +11,15 @@ from app.timetable.models.semester import Semester
 
 
 class Donor(AbstractPerson):
-    """Contact information for donors supporting students."""
+    """Contact information for donors supporting students.
+
+    Example:
+        >>> from app.people.models import Donor
+        >>> Donor.objects.create(user=user, donor_id="DN001")
+
+    Side Effects:
+        ``save()`` from :class:`AbstractPerson` populates ``donor_id``.
+    """
 
     ID_FIELD = "donor_id"
     ID_PREFIX = "TU_DNR"
@@ -25,7 +33,15 @@ class Donor(AbstractPerson):
 
 
 class Student(AbstractPerson):
-    """Extra academic information for enrolled students."""
+    """Extra academic information for enrolled students.
+
+    Example:
+        >>> from app.people.models import Student
+        >>> Student.objects.create(user=user, student_id="ST001", enrollment_semester=semester)
+
+    Side Effects:
+        ``save()`` from :class:`AbstractPerson` populates ``student_id``.
+    """
 
     ID_FIELD = "student_id"
     ID_PREFIX = "TU_STD"

--- a/app/people/models/role_assignment.py
+++ b/app/people/models/role_assignment.py
@@ -11,7 +11,12 @@ User = get_user_model()
 
 
 class RoleAssignment(models.Model):
-    """Period during which a user holds a specific role."""
+    """Period during which a user holds a specific role.
+
+    Example:
+        >>> from app.people.models import RoleAssignment
+        >>> RoleAssignment.objects.create(user=user, role=UserRole.ADMIN)
+    """
 
     user = models.ForeignKey(
         "auth.User", on_delete=models.CASCADE, related_name="role_assignments"

--- a/app/people/models/staffs.py
+++ b/app/people/models/staffs.py
@@ -18,6 +18,15 @@ User = get_user_model()
 
 
 class Faculty(StatusableMixin, models.Model):
+    """Teaching staff profile linked to a :class:`Staff` record.
+
+    Example:
+        >>> from app.people.models import Faculty
+        >>> Faculty.objects.create(staff_profile=staff, college=college)
+
+    Side Effects:
+        ``save()`` assigns the default college when none is set.
+    """
 
     staff_profile = models.OneToOneField("people.Staff", on_delete=models.CASCADE)
 
@@ -75,7 +84,15 @@ class Faculty(StatusableMixin, models.Model):
 
 
 class Staff(AbstractPerson):
-    """Base class for Staffs."""
+    """Base class for Staffs.
+
+    Example:
+        >>> from app.people.models import Staff
+        >>> Staff.objects.create(user=user, staff_id="ST01", department=dept)
+
+    Side Effects:
+        ``save()`` from :class:`AbstractPerson` sets ``staff_id``.
+    """
 
     ID_FIELD = "staff_id"
     ID_PREFIX = "TU_STF"

--- a/app/registry/models/class_roster.py
+++ b/app/registry/models/class_roster.py
@@ -10,7 +10,12 @@ from app.shared.constants import StatusRegistration
 
 
 class ClassRoster(models.Model):
-    """Container for the list of students enrolled in a section."""
+    """Container for the list of students enrolled in a section.
+
+    Example:
+        >>> from app.registry.models import ClassRoster
+        >>> ClassRoster.objects.create(section=section)
+    """
 
     section = models.OneToOneField("timetable.Section", on_delete=models.CASCADE)
     last_updated = models.DateTimeField(auto_now=True)

--- a/app/registry/models/document.py
+++ b/app/registry/models/document.py
@@ -17,6 +17,13 @@ class Document(StatusableMixin, models.Model):
 
     The ``profile`` generic relation allows attaching documents to different
     profile models (students, staff, etc.).
+
+    Example:
+        >>> from app.registry.models import Document
+        >>> Document.objects.create(profile=student, file="id.pdf", document_type=DocumentType.ID)
+
+    Side Effects:
+        Status changes are tracked via ``status_history``.
     """
 
     profile_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)

--- a/app/registry/models/grade.py
+++ b/app/registry/models/grade.py
@@ -4,7 +4,12 @@ from django.db import models
 
 
 class Grade(models.Model):
-    """Letter/numeric grade awarded to a student for a Section."""
+    """Letter/numeric grade awarded to a student for a Section.
+
+    Example:
+        >>> from app.registry.models import Grade
+        >>> Grade.objects.create(student=student, section=section, letter_grade="A", numeric_grade=90)
+    """
 
     student = models.ForeignKey("people.Student", on_delete=models.CASCADE)
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)

--- a/app/registry/models/registration.py
+++ b/app/registry/models/registration.py
@@ -13,7 +13,16 @@ from app.timetable.models import Reservation
 
 
 class Registration(StatusableMixin, models.Model):
-    """Enrollment of a student in a course section."""
+    """Enrollment of a student in a course section.
+
+    Example:
+        >>> from app.registry.models import Registration
+        >>> Registration.objects.create(student=student, section=section)
+
+    Side Effects:
+        ``date_latest_reservation`` is updated whenever a
+        :class:`~app.timetable.models.Reservation` is saved.
+    """
 
     student = models.ForeignKey(
         "people.Student",

--- a/app/spaces/models/core.py
+++ b/app/spaces/models/core.py
@@ -6,7 +6,12 @@ from django.db import models
 
 
 class Space(models.Model):
-    """Physical structure that groups multiple rooms."""
+    """Physical structure that groups multiple rooms.
+
+    Example:
+        >>> from app.spaces.models import Space
+        >>> Space.objects.create(code="AA", full_name="Academic Annex")
+    """
 
     code = models.CharField(max_length=15, unique=True, db_index=True)
     full_name = models.CharField(max_length=128, blank=True)
@@ -20,7 +25,12 @@ class Space(models.Model):
 
 
 class Room(models.Model):
-    """Individual teaching space located in a space."""
+    """Individual teaching space located in a space.
+
+    Example:
+        >>> from app.spaces.models import Room
+        >>> Room.objects.create(space=space, code="101")
+    """
 
     code = models.CharField(max_length=30)
     space = models.ForeignKey(

--- a/app/timetable/models/academic_year.py
+++ b/app/timetable/models/academic_year.py
@@ -10,7 +10,15 @@ from django.db.models.functions import ExtractYear
 
 
 class AcademicYear(models.Model):
-    """Top-level period covering two consecutive semesters."""
+    """Top-level period covering two consecutive semesters.
+
+    Example:
+        >>> from app.timetable.models import AcademicYear
+        >>> AcademicYear.objects.create(start_date=date(2025, 9, 1))
+
+    Side Effects:
+        ``save()`` computes ``code`` and ``long_name``.
+    """
 
     code = models.CharField(max_length=5, editable=False, unique=True)
     long_name = models.CharField(max_length=9, editable=False, unique=True)

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -25,6 +25,16 @@ if TYPE_CHECKING:
 
 
 class Reservation(StatusableMixin, models.Model):
+    """Student’s reservation of a seat in a section.
+
+    Example:
+        >>> from app.timetable.models import Reservation
+        >>> Reservation.objects.create(student=student, section=section)
+
+    Side Effects:
+        Signals adjust section registration counts when validated or deleted.
+    """
+
     student = models.ForeignKey(
         "people.Student",
         on_delete=models.CASCADE,

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -12,9 +12,17 @@ if TYPE_CHECKING:
 
 
 class Section(models.Model):
-    """
-    A single course offering in a given semester.
+    """A single course offering in a given semester.
+    
     A section can include multiple session rows.
+
+    Example:
+        >>> from app.timetable.models import Section
+        >>> Section.objects.create(course=course, semester=semester)
+
+    Side Effects:
+        Section numbers auto-increment and ``current_registrations``
+        are adjusted by reservation signals.
     """
 
     semester = models.ForeignKey("timetable.Semester", on_delete=models.PROTECT)

--- a/app/timetable/models/semester.py
+++ b/app/timetable/models/semester.py
@@ -7,7 +7,12 @@ from app.timetable.utils import validate_subperiod
 
 
 class Semester(models.Model):
-    """Half of an academic year (e.g. semester 1 or 2)."""
+    """Half of an academic year (e.g. semester 1 or 2).
+
+    Example:
+        >>> from app.timetable.models import Semester
+        >>> Semester.objects.create(academic_year=year, number=1)
+    """
 
     academic_year = models.ForeignKey("timetable.AcademicYear", on_delete=models.PROTECT)
     number = models.PositiveSmallIntegerField(

--- a/app/timetable/models/session.py
+++ b/app/timetable/models/session.py
@@ -9,6 +9,12 @@ from app.shared.enums import WEEKDAYS_NUMBER
 
 
 class Schedule(models.Model):
+    """Weekday/time slot used by :class:`Session`.
+
+    Example:
+        >>> from app.timetable.models import Schedule
+        >>> Schedule.objects.create(weekday=1, start_time=time(9, 0))
+    """
 
     # a ref date for the time
     REF_DATE = datetime(2009, 9, 1)
@@ -117,12 +123,11 @@ class Schedule(models.Model):
 
 
 class Session(models.Model):
-    """
-    A “meeting slot” for a Section:
-      - weekday (1=Monday … 7=Sunday)
-      - start_time / end_time
-      - space (Room)
-      - which Section this slot belongs to
+    """A meeting slot for a :class:`Section`.
+
+    Example:
+        >>> from app.timetable.models import Session
+        >>> Session.objects.create(room=room, schedule=schedule, section=section)
     """
 
     room = models.ForeignKey("spaces.Room", on_delete=models.PROTECT)

--- a/app/timetable/models/term.py
+++ b/app/timetable/models/term.py
@@ -8,7 +8,12 @@ from app.timetable.utils import validate_subperiod
 
 
 class Term(models.Model):
-    """One of the sub-periods that divide a semester."""
+    """One of the sub-periods that divide a semester.
+
+    Example:
+        >>> from app.timetable.models import Term
+        >>> Term.objects.create(semester=semester, number=1)
+    """
 
     semester = models.ForeignKey(
         "timetable.Semester", on_delete=models.PROTECT, related_name="terms"


### PR DESCRIPTION
## Summary
- expand docstrings in models to show creation examples
- mention key side effects like signals and status history

## Testing
- `pytest -q` *(fails: pyenv complains pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851e3dd38e88323801c075b8a375286