### PR TITLE
Add usage examples in model docstrings

### DIFF
--- a/app/academics/models/college.py
+++ b/app/academics/models/college.py
@@ -9,7 +9,11 @@ from app.shared.constants.academics import CollegeCodeChoices, CollegeLongNameCh
 
 
 class College(models.Model):
-    """Institutional unit responsible for a set of programmes."""
+    """Institutional unit responsible for a set of programmes.
+
+    Example:
+        >>> college_factory(code="COAS")
+    """
 
     # there should be no constraint here as the VPA may need to
     # rework the name of the colleges from time to time.

--- a/app/academics/models/concentration.py
+++ b/app/academics/models/concentration.py
@@ -6,7 +6,11 @@ from django.db import models
 
 
 class Concentration(models.Model):
-    """Optional specialization that further narrows a curriculum."""
+    """Optional specialization that further narrows a curriculum.
+
+    Example:
+        >>> Concentration.objects.create(name="Agro", curriculum=curriculum)
+    """
 
     # revoir
     name = models.CharField(max_length=255)

--- a/app/academics/models/course.py
+++ b/app/academics/models/course.py
@@ -10,7 +10,11 @@ from app.academics.models.curriculum import Curriculum
 
 
 class Course(models.Model):
-    """University catalogue entry describing a single course offering."""
+    """University catalogue entry describing a single course offering.
+
+    Example:
+        >>> course_factory(name="CSC", number="101", title="Intro")
+    """
 
     code = models.CharField(max_length=20, editable=False)
     # > need to change it and everywhere with course_dept

--- a/app/academics/models/curriculum.py
+++ b/app/academics/models/curriculum.py
@@ -10,7 +10,12 @@ from app.shared.mixins import StatusableMixin
 
 
 class Curriculum(StatusableMixin, models.Model):
-    """Set of courses that make up a degree programme within a college."""
+    """Set of courses that make up a degree programme within a college.
+
+    Example:
+        >>> curriculum = Curriculum.objects.create(short_name="BSc", college=college)
+        >>> curriculum.set_pending(author=None)
+    """
 
     short_name = models.CharField(max_length=40)
     long_name = models.CharField(max_length=255, blank=True, null=True)

--- a/app/academics/models/curriculum_course.py
+++ b/app/academics/models/curriculum_course.py
@@ -8,7 +8,11 @@ from app.shared.enums import CREDIT_NUMBER
 
 
 class CurriculumCourse(models.Model):
-    """Map :class:`Curriculum` instances to their constituent courses."""
+    """Map :class:`Curriculum` instances to their constituent courses.
+
+    Example:
+        >>> CurriculumCourse.objects.create(curriculum=curriculum, course=course)
+    """
 
     curriculum = models.ForeignKey(
         "academics.Curriculum", on_delete=models.CASCADE, related_name="programme_lines"

--- a/app/academics/models/department.py
+++ b/app/academics/models/department.py
@@ -6,7 +6,11 @@ from django.db import models
 
 
 class Department(models.Model):
-    """Academic department belonging to a college."""
+    """Academic department belonging to a college.
+
+    Example:
+        >>> department_factory(code="ENG")
+    """
 
     code = models.CharField(max_length=50, unique=True)
     full_name = models.CharField(max_length=128, blank=True)

--- a/app/academics/models/prerequisite.py
+++ b/app/academics/models/prerequisite.py
@@ -7,7 +7,14 @@ from django.db import models
 
 
 class Prerequisite(models.Model):
-    """Relationship describing that one course must precede another."""
+    """Relationship describing that one course must precede another.
+
+    Example:
+        >>> Prerequisite.objects.create(
+        ...     course=course,
+        ...     prerequisite_course=prereq,
+        ... )
+    """
 
     course = models.ForeignKey(
         "academics.Course", related_name="course_prereq_edges", on_delete=models.CASCADE

--- a/app/finance/models/financial_record.py
+++ b/app/finance/models/financial_record.py
@@ -8,7 +8,11 @@ from app.shared.constants.finance import FeeType, StatusClearance
 
 
 class FinancialRecord(models.Model):
-    """Aggregate balance for a student."""
+    """Aggregate balance for a student.
+
+    Example:
+        >>> FinancialRecord.objects.create(student=student_profile, total_due=0)
+    """
 
     student = models.OneToOneField("people.Student", on_delete=models.CASCADE)
     total_due = models.DecimalField(max_digits=10, decimal_places=2)
@@ -28,7 +32,11 @@ class FinancialRecord(models.Model):
 
 
 class SectionFee(models.Model):
-    """Additional fee charged for a specific course section."""
+    """Additional fee charged for a specific course section.
+
+    Example:
+        >>> SectionFee.objects.create(section=section, fee_type=FeeType.LAB, amount=50)
+    """
 
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)
     fee_type = models.CharField(max_length=50, choices=FeeType.choices)

--- a/app/finance/models/payment.py
+++ b/app/finance/models/payment.py
@@ -8,7 +8,15 @@ from app.shared.constants import PaymentMethod
 
 
 class Payment(models.Model):
-    """Payment made for a reservation."""
+    """Payment made for a reservation.
+
+    Example:
+        >>> Payment.objects.create(
+        ...     reservation=reservation,
+        ...     amount=Decimal("10.00"),
+        ...     method=PaymentMethod.CASH,
+        ... )
+    """
 
     reservation = models.OneToOneField("timetable.Reservation", on_delete=models.CASCADE)
     amount = models.DecimalField(max_digits=8, decimal_places=2)

--- a/app/finance/models/payment_history.py
+++ b/app/finance/models/payment_history.py
@@ -6,7 +6,14 @@ from django.db import models
 
 
 class PaymentHistory(models.Model):
-    """Individual payment made toward a financial record."""
+    """Individual payment made toward a financial record.
+
+    Example:
+        >>> PaymentHistory.objects.create(
+        ...     financial_record=record,
+        ...     amount=Decimal("20.00"),
+        ... )
+    """
 
     financial_record = models.ForeignKey(
         "finance.FinancialRecord", related_name="payments", on_delete=models.CASCADE

--- a/app/finance/models/scholarship.py
+++ b/app/finance/models/scholarship.py
@@ -6,7 +6,16 @@ from django.db import models
 
 
 class Scholarship(models.Model):
-    """Financial aid linking a donor to a student."""
+    """Financial aid linking a donor to a student.
+
+    Example:
+        >>> Scholarship.objects.create(
+        ...     donor=donor,
+        ...     student=student_profile,
+        ...     amount=Decimal("100"),
+        ...     start_date=date.today(),
+        ... )
+    """
 
     donor = models.ForeignKey(
         "people.Donor",

--- a/app/people/models/core.py
+++ b/app/people/models/core.py
@@ -22,6 +22,12 @@ def photo_upload_to(instance: "AbstractPerson", filename: str) -> str:
 
 
 class AbstractPerson(StatusableMixin, models.Model):
+    """Base information shared by all people profiles.
+
+    Example:
+        >>> user = User.objects.create_user(username="demo")
+        >>> Student.objects.create(user=user, student_id="S1", enrollment_semester=semester)
+    """
 
     ID_FIELD: str | None = None
     ID_PREFIX: str = "TU_"

--- a/app/people/models/others.py
+++ b/app/people/models/others.py
@@ -11,7 +11,12 @@ from app.timetable.models.semester import Semester
 
 
 class Donor(AbstractPerson):
-    """Contact information for donors supporting students."""
+    """Contact information for donors supporting students.
+
+    Example:
+        >>> user = User.objects.create_user(username="donor")
+        >>> Donor.objects.create(user=user, donor_id="DN001")
+    """
 
     ID_FIELD = "donor_id"
     ID_PREFIX = "TU_DNR"
@@ -25,7 +30,14 @@ class Donor(AbstractPerson):
 
 
 class Student(AbstractPerson):
-    """Extra academic information for enrolled students."""
+    """Extra academic information for enrolled students.
+
+    Example:
+        >>> user = User.objects.create_user(username="stud")
+        >>> s = Student.objects.create(user=user, enrollment_semester=semester)
+        >>> s.student_id  # auto-set from user id
+        'TU_STD0001'
+    """
 
     ID_FIELD = "student_id"
     ID_PREFIX = "TU_STD"

--- a/app/people/models/role_assignment.py
+++ b/app/people/models/role_assignment.py
@@ -11,7 +11,15 @@ User = get_user_model()
 
 
 class RoleAssignment(models.Model):
-    """Period during which a user holds a specific role."""
+    """Period during which a user holds a specific role.
+
+    Example:
+        >>> RoleAssignment.objects.create(
+        ...     user=user,
+        ...     role=UserRole.REGISTRAR,
+        ...     start_date=date.today(),
+        ... )
+    """
 
     user = models.ForeignKey(
         "auth.User", on_delete=models.CASCADE, related_name="role_assignments"

--- a/app/people/models/staffs.py
+++ b/app/people/models/staffs.py
@@ -18,6 +18,11 @@ User = get_user_model()
 
 
 class Faculty(StatusableMixin, models.Model):
+    """Instructor profile linked to a staff member.
+
+    Example:
+        >>> faculty_profile  # from tests.conftest
+    """
 
     staff_profile = models.OneToOneField("people.Staff", on_delete=models.CASCADE)
 
@@ -75,7 +80,11 @@ class Faculty(StatusableMixin, models.Model):
 
 
 class Staff(AbstractPerson):
-    """Base class for Staffs."""
+    """Base class for Staffs.
+
+    Example:
+        >>> staff_profile  # from tests.conftest
+    """
 
     ID_FIELD = "staff_id"
     ID_PREFIX = "TU_STF"

--- a/app/registry/models/class_roster.py
+++ b/app/registry/models/class_roster.py
@@ -10,7 +10,13 @@ from app.shared.constants import StatusRegistration
 
 
 class ClassRoster(models.Model):
-    """Container for the list of students enrolled in a section."""
+    """Container for the list of students enrolled in a section.
+
+    Example:
+        >>> roster = ClassRoster.objects.create(section=section)
+        >>> roster.students.count()
+        0
+    """
 
     section = models.OneToOneField("timetable.Section", on_delete=models.CASCADE)
     last_updated = models.DateTimeField(auto_now=True)

--- a/app/registry/models/document.py
+++ b/app/registry/models/document.py
@@ -17,6 +17,14 @@ class Document(StatusableMixin, models.Model):
 
     The ``profile`` generic relation allows attaching documents to different
     profile models (students, staff, etc.).
+
+    Example:
+        >>> doc = Document.objects.create(
+        ...     profile=student_profile,
+        ...     file="id.pdf",
+        ...     document_type=DocumentType.ID_CARD,
+        ... )
+        >>> doc.set_pending(author=None)
     """
 
     profile_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)

--- a/app/registry/models/grade.py
+++ b/app/registry/models/grade.py
@@ -4,7 +4,16 @@ from django.db import models
 
 
 class Grade(models.Model):
-    """Letter/numeric grade awarded to a student for a Section."""
+    """Letter/numeric grade awarded to a student for a Section.
+
+    Example:
+        >>> Grade.objects.create(
+        ...     student=student_profile,
+        ...     section=section_factory(1),
+        ...     letter_grade="A",
+        ...     numeric_grade=95,
+        ... )
+    """
 
     student = models.ForeignKey("people.Student", on_delete=models.CASCADE)
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)

--- a/app/registry/models/registration.py
+++ b/app/registry/models/registration.py
@@ -13,7 +13,21 @@ from app.timetable.models import Reservation
 
 
 class Registration(StatusableMixin, models.Model):
-    """Enrollment of a student in a course section."""
+    """Enrollment of a student in a course section.
+
+    Example:
+        >>> reg = Registration.objects.create(
+        ...     student=student_profile,
+        ...     section=section_factory(1),
+        ... )
+        >>> Reservation.objects.create(
+        ...     student=reg.student,
+        ...     section=reg.section,
+        ... )  # signal sets ``date_latest_reservation``
+        >>> reg.refresh_from_db()
+        >>> reg.date_latest_reservation is not None
+        True
+    """
 
     student = models.ForeignKey(
         "people.Student",

--- a/app/spaces/models/core.py
+++ b/app/spaces/models/core.py
@@ -6,7 +6,11 @@ from django.db import models
 
 
 class Space(models.Model):
-    """Physical structure that groups multiple rooms."""
+    """Physical structure that groups multiple rooms.
+
+    Example:
+        >>> Space.objects.create(code="AA", full_name="Academic Annex")
+    """
 
     code = models.CharField(max_length=15, unique=True, db_index=True)
     full_name = models.CharField(max_length=128, blank=True)
@@ -20,7 +24,11 @@ class Space(models.Model):
 
 
 class Room(models.Model):
-    """Individual teaching space located in a space."""
+    """Individual teaching space located in a space.
+
+    Example:
+        >>> Room.objects.create(code="101", space=space)
+    """
 
     code = models.CharField(max_length=30)
     space = models.ForeignKey(

--- a/app/timetable/models/academic_year.py
+++ b/app/timetable/models/academic_year.py
@@ -10,7 +10,11 @@ from django.db.models.functions import ExtractYear
 
 
 class AcademicYear(models.Model):
-    """Top-level period covering two consecutive semesters."""
+    """Top-level period covering two consecutive semesters.
+
+    Example:
+        >>> AcademicYear.objects.create(start_date=date(2025, 9, 1))
+    """
 
     code = models.CharField(max_length=5, editable=False, unique=True)
     long_name = models.CharField(max_length=9, editable=False, unique=True)

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -25,6 +25,16 @@ if TYPE_CHECKING:
 
 
 class Reservation(StatusableMixin, models.Model):
+    """Student request to enroll in a section.
+
+    Example:
+        >>> reservation = Reservation.objects.create(
+        ...     student=student_profile,
+        ...     section=section_factory(1),
+        ... )
+        >>> reservation.mark_paid(by_user=staff_profile)
+    """
+
     student = models.ForeignKey(
         "people.Student",
         on_delete=models.CASCADE,

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -12,9 +12,10 @@ if TYPE_CHECKING:
 
 
 class Section(models.Model):
-    """
-    A single course offering in a given semester.
-    A section can include multiple session rows.
+    """A single course offering in a given semester.
+
+    Example:
+        >>> Section.objects.create(course=course, semester=semester, number=1)
     """
 
     semester = models.ForeignKey("timetable.Semester", on_delete=models.PROTECT)

--- a/app/timetable/models/semester.py
+++ b/app/timetable/models/semester.py
@@ -7,7 +7,14 @@ from app.timetable.utils import validate_subperiod
 
 
 class Semester(models.Model):
-    """Half of an academic year (e.g. semester 1 or 2)."""
+    """Half of an academic year (e.g. semester 1 or 2).
+
+    Example:
+        >>> semester = Semester.objects.create(
+        ...     academic_year=academic_year,
+        ...     number=1,
+        ... )
+    """
 
     academic_year = models.ForeignKey("timetable.AcademicYear", on_delete=models.PROTECT)
     number = models.PositiveSmallIntegerField(

--- a/app/timetable/models/session.py
+++ b/app/timetable/models/session.py
@@ -9,6 +9,11 @@ from app.shared.enums import WEEKDAYS_NUMBER
 
 
 class Schedule(models.Model):
+    """Time slot definition used by session objects.
+
+    Example:
+        >>> Schedule.objects.create(weekday=1, start_time=time(9, 0))
+    """
 
     # a ref date for the time
     REF_DATE = datetime(2009, 9, 1)
@@ -117,12 +122,10 @@ class Schedule(models.Model):
 
 
 class Session(models.Model):
-    """
-    A “meeting slot” for a Section:
-      - weekday (1=Monday … 7=Sunday)
-      - start_time / end_time
-      - space (Room)
-      - which Section this slot belongs to
+    """A meeting slot for a Section.
+
+    Example:
+        >>> Session.objects.create(room=room, schedule=schedule, section=section)
     """
 
     room = models.ForeignKey("spaces.Room", on_delete=models.PROTECT)

--- a/app/timetable/models/term.py
+++ b/app/timetable/models/term.py
@@ -8,7 +8,11 @@ from app.timetable.utils import validate_subperiod
 
 
 class Term(models.Model):
-    """One of the sub-periods that divide a semester."""
+    """One of the sub-periods that divide a semester.
+
+    Example:
+        >>> Term.objects.create(semester=semester, number=1)
+    """
 
     semester = models.ForeignKey(
         "timetable.Semester", on_delete=models.PROTECT, related_name="terms"


### PR DESCRIPTION
## Summary
- document how to instantiate models in each `app/**/models/*.py`
- show factories or important side-effects in examples

## Testing
- `black app/`
- `flake8 app/`
- `mypy app/` *(fails: mypy_django_plugin TypeError)*
- `pytest -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_6851e403b0648323a2cd32bd3aeb1e34