### PR TITLE
Add admin docstrings

### DIFF
--- a/app/academics/admin/core.py
+++ b/app/academics/admin/core.py
@@ -34,7 +34,18 @@ from .resources import (
 
 @admin.register(Course)
 class CourseAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin interface configuration for :class:`~app.academics.models.Course`."""
+    """Admin interface for :class:`~app.academics.models.Course`.
+
+    Provides course management with extra tools:
+    * ``list_display`` shows the code, title, credits and college fields.
+    * ``list_filter`` allows filtering by curriculum.
+    * ``inlines`` embed related sections and prerequisite relations.
+    * ``actions`` exposes the ``update_college`` bulk action.
+
+    Example:
+        Select multiple courses and choose **Update college** from the actions
+        dropdown to assign them all to a different college.
+    """
 
     resource_class = CourseResource
     list_display = ("code", "title", "credit_hours", "college")
@@ -72,7 +83,17 @@ class CourseAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(Prerequisite)
 class PrerequisiteAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin interface for :class:`~app.academics.models.Prerequisite`."""
+    """Admin interface for :class:`~app.academics.models.Prerequisite`.
+
+    Options configured:
+    * ``list_display`` shows the course, the prerequisite and the curriculum.
+    * ``list_filter`` uses :class:`CurriculumFilter` to narrow by curriculum.
+    * ``actions`` provides ``update_curriculum`` for bulk updates.
+
+    Example:
+        On the prerequisites list page, select rows and run
+        **Attach / update curriculum** to set a curriculum for them.
+    """
 
     resource_class = PrerequisiteResource
     actions = [update_curriculum]
@@ -84,7 +105,15 @@ class PrerequisiteAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(Curriculum)
 class CurriculumAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin options for :class:`~app.academics.models.Curriculum`."""
+    """Admin options for :class:`~app.academics.models.Curriculum`.
+
+    Key features:
+    * Uses ``BulkActionImportForm`` for import/export with an extra action
+      button.
+    * ``inlines`` manage related curriculum courses inline.
+    * ``list_display`` includes short and long names with the college.
+    * ``list_filter`` allows filtering by college and active state.
+    """
 
     resource_class = CurriculumResource
     # add the action button on the import form
@@ -100,7 +129,11 @@ class CurriculumAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(College)
 class CollegeAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin interface for :class:`~app.academics.models.College`."""
+    """Admin settings for :class:`~app.academics.models.College`.
+
+    Displays the college code and name and provides search capability on both
+    fields via ``list_display`` and ``search_fields``.
+    """
 
     resource_class = CollegeResource
     list_display = ("code", "long_name")
@@ -109,7 +142,11 @@ class CollegeAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(Department)
 class DepartmentAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin interface for :class:`~app.academics.models.Department`."""
+    """Admin interface for :class:`~app.academics.models.Department`.
+
+    Shows department code, name and college. ``autocomplete_fields`` speeds up
+    college selection when editing a department.
+    """
 
     resource_class = DepartmentResource
     list_display = ("code", "full_name", "college")
@@ -119,7 +156,12 @@ class DepartmentAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(CurriculumCourse)
 class CurriculumCourseAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin screen for :class:`~app.academics.models.CurriculumCourse`."""
+    """Admin screen for :class:`~app.academics.models.CurriculumCourse`.
+
+    ``list_display`` shows the curriculum and related course while
+    ``autocomplete_fields`` make lookups faster. ``list_select_related`` joins
+    both relations for efficient queries.
+    """
 
     resource_class = CurriculumCourseResource
     list_display = ("curriculum", "course")

--- a/app/academics/admin/inlines.py
+++ b/app/academics/admin/inlines.py
@@ -6,6 +6,8 @@ from app.academics.models import Prerequisite, CurriculumCourse
 
 
 class RequiresInline(admin.TabularInline):
+    """Inline editor for :class:`~app.academics.models.Prerequisite` needed by a course."""
+
     model = Prerequisite
     fk_name = "course"
     verbose_name_plural = "Prerequisites this course needs"
@@ -14,6 +16,8 @@ class RequiresInline(admin.TabularInline):
 
 
 class PrerequisiteInline(admin.TabularInline):
+    """Inline showing courses that depend on the current course."""
+
     model = Prerequisite
     fk_name = "prerequisite_course"
     verbose_name_plural = "Courses that require this course"
@@ -22,6 +26,8 @@ class PrerequisiteInline(admin.TabularInline):
 
 
 class CurriculumCourseInline(admin.TabularInline):
+    """Inline for linking courses to a curriculum."""
+
     model = CurriculumCourse
     extra = 0
     autocomplete_fields = ("course",)

--- a/app/finance/admin/core.py
+++ b/app/finance/admin/core.py
@@ -10,7 +10,11 @@ from app.finance.models.scholarship import Scholarship
 
 @admin.register(Payment)
 class PaymentAdmin(admin.ModelAdmin):
-    """Admin settings for :class:`~app.finance.models.Payment`."""
+    """Admin settings for :class:`~app.finance.models.Payment`.
+
+    Uses ``list_display`` to show reservation, method and recorder and marks
+    ``created_at`` as read-only.
+    """
 
     # Use Payment.__str__ for readability in list views
     list_display = ("__str__", "reservation", "method", "recorded_by")
@@ -19,7 +23,11 @@ class PaymentAdmin(admin.ModelAdmin):
 
 @admin.register(Scholarship)
 class ScholarshipAdmin(admin.ModelAdmin):
-    """Admin interface for :class:`~app.finance.models.Scholarship`."""
+    """Admin interface for :class:`~app.finance.models.Scholarship`.
+
+    Autocomplete is enabled for donor and student foreign keys and key fields
+    are displayed in the list view.
+    """
 
     list_display = ("student", "donor", "amount", "start_date", "end_date")
     autocomplete_fields = ("donor", "student")
@@ -27,7 +35,11 @@ class ScholarshipAdmin(admin.ModelAdmin):
 
 @admin.register(PaymentHistory)
 class PaymentHistoryAdmin(admin.ModelAdmin):
-    """Admin interface for :class:`~app.finance.models.PaymentHistory`."""
+    """Admin interface for :class:`~app.finance.models.PaymentHistory`.
+
+    Shows a summary string along with the record, payment method and user.
+    Payment date is shown but cannot be edited.
+    """
 
     # Shows summary string plus related info
     list_display = ("__str__", "financial_record", "method", "recorded_by")

--- a/app/people/admin/core.py
+++ b/app/people/admin/core.py
@@ -10,7 +10,11 @@ from import_export.admin import ImportExportModelAdmin
 
 @admin.register(Faculty)
 class FacultyAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin options for :class:`~app.people.models.Faculty`."""
+    """Admin options for :class:`~app.people.models.Faculty`.
+
+    Displays the staff profile with optional filtering by college. The faculty
+    resource is used for import/export operations.
+    """
 
     resource_class = FacultyResource
     fields = (
@@ -34,7 +38,10 @@ class FacultyAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(Donor)
 class DonorAdmin(GuardedModelAdmin):
-    """Admin management for :class:`~app.people.models.Donor`."""
+    """Admin management for :class:`~app.people.models.Donor`.
+
+    Shows each donor's user and ID with autocomplete for the user relation.
+    """
 
     list_display = ("user", "donor_id")
     search_fields = (
@@ -48,7 +55,11 @@ class DonorAdmin(GuardedModelAdmin):
 
 @admin.register(Staff)
 class StaffAdmin(GuardedModelAdmin):
-    """Admin management for :class:`~app.people.models.Staff`."""
+    """Admin management for :class:`~app.people.models.Staff`.
+
+    Provides detailed fieldsets for personal and work information. Important
+    fields like ``staff_id`` are read-only to avoid accidental edits.
+    """
 
     fieldsets = (
         (
@@ -107,7 +118,11 @@ class StaffAdmin(GuardedModelAdmin):
 
 @admin.register(Student)
 class StudentAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin interface for :class:`~app.people.models.Student`."""
+    """Admin interface for :class:`~app.people.models.Student`.
+
+    ``list_display`` shows the related user and student ID with search enabled
+    on both fields. Import/export is supported via ``ImportExportModelAdmin``.
+    """
 
     list_display = ("user", "student_id")
     search_fields = (

--- a/app/registry/admin/core.py
+++ b/app/registry/admin/core.py
@@ -7,7 +7,11 @@ from app.registry.models import ClassRoster, Grade
 
 @admin.register(Grade)
 class GradeAdmin(admin.ModelAdmin):
-    """Admin interface for :class:`~app.registry.models.Grade`."""
+    """Admin interface for :class:`~app.registry.models.Grade`.
+
+    Shows student, section and grade fields in the list view with autocomplete
+    lookups for student and section.
+    """
 
     list_display = (
         "student",
@@ -29,7 +33,11 @@ class GradeAdmin(admin.ModelAdmin):
 
 @admin.register(ClassRoster)
 class ClassRosterAdmin(admin.ModelAdmin):
-    """Admin interface for :class:`~app.registry.models.ClassRoster`."""
+    """Admin interface for :class:`~app.registry.models.ClassRoster`.
+
+    Displays the section and counts enrolled students via ``student_count``.
+    The ``section`` foreign key is autocompleted for convenience.
+    """
 
     list_display = ("section", "student_count", "last_updated")
     search_fields = (

--- a/app/spaces/admin/core.py
+++ b/app/spaces/admin/core.py
@@ -11,7 +11,10 @@ from app.spaces.models import Space, Room
 
 @admin.register(Space)
 class SpaceAdmin(GuardedModelAdmin):
-    """Admin management for :class:`~app.spaces.models.Space`."""
+    """Admin management for :class:`~app.spaces.models.Space`.
+
+    Exposes basic listing and search over the space code and name.
+    """
 
     search_fields = ("code", "full_name")
     list_display = ("code", "full_name")
@@ -19,7 +22,12 @@ class SpaceAdmin(GuardedModelAdmin):
 
 @admin.register(Room)
 class RoomAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin configuration for :class:`~app.spaces.models.Room`."""
+    """Admin configuration for :class:`~app.spaces.models.Room`.
+
+    ``list_display`` shows the room code and capacities. Sessions are edited via
+    ``SessionInline``. The ``full_code`` field is read‑only and the space
+    relation uses autocomplete.
+    """
 
     resource_class = RoomResource
     fields = (

--- a/app/timetable/admin/inlines.py
+++ b/app/timetable/admin/inlines.py
@@ -8,6 +8,8 @@ from app.timetable.models import Section, Semester
 
 
 class SemesterInline(admin.TabularInline):
+    """Inline for managing :class:`~app.timetable.models.Semester` rows."""
+
     model = Semester
     extra = 0
     max_num = 3
@@ -16,6 +18,8 @@ class SemesterInline(admin.TabularInline):
 
 
 class SessionInline(admin.TabularInline):
+    """Inline editor for :class:`~app.timetable.models.Session`."""
+
     model = Session
     extra = 0
     fields = ("room", "schedule")
@@ -23,6 +27,8 @@ class SessionInline(admin.TabularInline):
 
 
 class SectionInline(admin.TabularInline):
+    """Inline for creating :class:`~app.timetable.models.Section` rows."""
+
     model = Section
     extra = 0
     fields = (
@@ -39,7 +45,10 @@ class SectionInline(admin.TabularInline):
 
 
 class ReservationInline(admin.TabularInline):
-    """Display reservations inline with credit hours snapshot."""
+    """Inline for :class:`~app.timetable.models.Reservation` records.
+
+    Shows each reservation with status and credit hour snapshot.
+    """
 
     model = Reservation
     extra = 0

--- a/app/timetable/admin/registers/core.py
+++ b/app/timetable/admin/registers/core.py
@@ -11,7 +11,12 @@ from app.timetable.models import AcademicYear, Semester
 
 @admin.register(AcademicYear)
 class AcademicYearAdmin(GuardedModelAdmin):
-    """Admin settings for :class:`~app.timetable.models.AcademicYear`."""
+    """Admin settings for :class:`~app.timetable.models.AcademicYear`.
+
+    Displays academic year information and embeds semesters via
+    ``SemesterInline``. The listing is ordered by start date in descending
+    order and grouped by the start date hierarchy.
+    """
 
     list_display = ("long_name", "start_date", "end_date", "code")
     date_hierarchy = "start_date"
@@ -21,7 +26,11 @@ class AcademicYearAdmin(GuardedModelAdmin):
 
 @admin.register(Semester)
 class SemesterAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin configuration for :class:`~app.timetable.models.Semester`."""
+    """Admin configuration for :class:`~app.timetable.models.Semester`.
+
+    Provides import/export support and filters semesters by academic year.
+    ``list_display`` shows the academic year, number and date range.
+    """
 
     resource_class = SemesterResource
     list_display = ("academic_year", "number", "start_date", "end_date")

--- a/app/timetable/admin/registers/reservation.py
+++ b/app/timetable/admin/registers/reservation.py
@@ -8,7 +8,15 @@ from django.contrib import admin
 
 @admin.register(Reservation)
 class ReservationAdmin(admin.ModelAdmin):
-    """Admin interface for :class:`~app.timetable.models.Reservation`."""
+    """Admin interface for :class:`~app.timetable.models.Reservation`.
+
+    ``list_display`` shows student, section, status and fee details. Two custom
+    actions allow validating or marking reservations as paid.
+
+    Example:
+        Select reservations and choose **Validate reservation** to confirm
+        them or **Mark paid** once payment is received.
+    """
 
     list_display = (
         "student",

--- a/app/timetable/admin/registers/section.py
+++ b/app/timetable/admin/registers/section.py
@@ -11,7 +11,12 @@ from app.timetable.models.section import Section
 
 @admin.register(Section)
 class SectionAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin interface for :class:`~app.timetable.models.Section`."""
+    """Admin interface for :class:`~app.timetable.models.Section`.
+
+    ``list_display`` includes semester, course and faculty information while
+    ``inlines`` manage reservations and sessions. Filtering by curriculum is
+    available through ``list_filter``.
+    """
 
     # ! TODO ajouter à la list, les rooms occupé et le nombre de sessions, le nombre de crédits
     resource_class = SectionResource

--- a/app/timetable/admin/registers/session.py
+++ b/app/timetable/admin/registers/session.py
@@ -10,7 +10,11 @@ from app.timetable.models.session import Schedule, Session
 
 @admin.register(Session)
 class SessionAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin configuration for :class:`Session`."""
+    """Admin configuration for :class:`~app.timetable.models.Session`.
+
+    ``list_display`` exposes schedule, room and related section details. The
+    list can be filtered by weekday or space.
+    """
 
     resource_class = SessionResource
     list_display = (
@@ -30,7 +34,10 @@ class SessionAdmin(ImportExportModelAdmin, GuardedModelAdmin):
 
 @admin.register(Schedule)
 class ScheduleAdmin(ImportExportModelAdmin, GuardedModelAdmin):
-    """Admin for Schedule"""
+    """Admin interface for :class:`~app.timetable.models.Schedule`.
+
+    Allows filtering by weekday and supports import/export operations.
+    """
 
     resource_class = ScheduleResource
     list_display = ("weekday", "start_time", "end_time")


### PR DESCRIPTION
## Summary
- document options for Course, Prerequisite, Curriculum and more admin classes
- add notes to inline classes in timetable and academics
- clarify features in finance, people, spaces and registry admins
- mention actions for ReservationAdmin

## Testing
- `python3 -m black --check app/academics/admin/core.py app/academics/admin/inlines.py app/finance/admin/core.py app/people/admin/core.py app/registry/admin/core.py app/spaces/admin/core.py app/timetable/admin/inlines.py app/timetable/admin/registers/core.py app/timetable/admin/registers/reservation.py app/timetable/admin/registers/section.py app/timetable/admin/registers/session.py`
- `flake8 app/academics/admin/core.py app/academics/admin/inlines.py app/finance/admin/core.py app/people/admin/core.py app/registry/admin/core.py app/spaces/admin/core.py app/timetable/admin/inlines.py app/timetable/admin/registers/core.py app/timetable/admin/registers/reservation.py app/timetable/admin/registers/section.py app/timetable/admin/registers/session.py`
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6851e41306608323962a663d07ef2aa9