### PR TITLE
Add docstrings for DB reset command

### DIFF
--- a/app/shared/management/commands/reset_db.py
+++ b/app/shared/management/commands/reset_db.py
@@ -1,24 +1,31 @@
-"""Reset db module."""
+"""Management command for resetting the database.
+
+Drops all tables from the current schema so you can start from a clean
+database. The operation is irreversible and should only be used in
+development. There is no confirmation prompt.
+
+Example:
+    To rebuild the schema after removing all tables run::
+
+        python manage.py reset_db
+        python manage.py migrate
+        python manage.py populate_initial_data
+"""
 
 from django.core.management.base import BaseCommand
 from django.db import connection
 
-"""Drop all tables to start from a clean database.
-
-Usage::
-    python manage.py reset_db
-
-Follow with::
-    python manage.py migrate
-    python manage.py populate_initial_data
-"""
-
 
 class Command(BaseCommand):
-    """
-    python manage.py reset_db
-    python manage.py migrate
-    python manage.py populate_initial_data
+    """Drop all tables from the default database.
+
+    This command iterates over every table in the current schema and issues a
+    ``DROP TABLE ... CASCADE`` statement. It is useful for resetting a local
+    database when starting development from scratch.
+
+    Warning:
+        This operation is destructive and should never be executed on a
+        production database.
     """
 
     help = "Completely resets the database by dropping all tables."


### PR DESCRIPTION
## Summary
- explain the reset_db command using Google-style module and class docs

## Testing
- `pytest -q` *(fails: import file mismatch in app/website/tests.py)*

------
https://chatgpt.com/codex/tasks/task_e_6851e41e29948323909475a97968abc4