### PR TITLE
Improve docstrings

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+
+"""Initialize the Django application package."""

--- a/app/academics/admin/actions.py
+++ b/app/academics/admin/actions.py
@@ -12,8 +12,8 @@ from app.academics.models import Curriculum, College  # the target model
 
 @admin.action(description="Attach / update curriculum on selected prerequisites")
 def update_curriculum(modeladmin, request, queryset):
-    """
-    Bulk-update the ``curriculum`` FK on Prerequisite rows picked in the change list.
+    """Bulk-update the ``curriculum`` FK on selected prerequisites.
+
     Works in two steps:
       1. GET  → show a tiny form asking for the Curriculum.
       2. POST → apply it and send a flash message.

--- a/app/timetable/admin/widgets/section.py
+++ b/app/timetable/admin/widgets/section.py
@@ -20,9 +20,7 @@ class SectionWidget(widgets.ForeignKeyWidget):
 
     # ------------ widget API ------------
     def clean(self, value, row=None, *args, **kwargs) -> Section | None:
-        """
-        *value* is ignored (we rely entirely on the other columns).
-        """
+        """Return the ``Section`` referenced by the CSV row."""
         if row is None:
             raise ValueError("Row context required")
 
@@ -63,7 +61,7 @@ class SectionCodeWidget(widgets.Widget):
         *args,
         **kwargs,
     ) -> Section | None:
-        "Expecting the value to be"
+        """Return the ``Section`` identified by the import code string."""
 
         course_name_value = row.get("course_name", "").strip()
         course = self.crs_w.clean(value=course_name_value, row=row)

--- a/app/timetable/admin/widgets/session.py
+++ b/app/timetable/admin/widgets/session.py
@@ -40,9 +40,7 @@ class ScheduleWidget(widgets.ForeignKeyWidget):
         self.weekday_w = WeekdayWidget
 
     def clean(self, value, row=None, *args, **kwargs) -> Schedule | None:
-        """
-        We get the weekday but start and end time should be present in row
-        """
+        """Return an existing ``Schedule`` using data from the import row."""
 
         weekday: int | None = self.weekday_w().clean(value=value)
         if weekday is None:

--- a/app/timetable/apps.py
+++ b/app/timetable/apps.py
@@ -9,7 +9,5 @@ class TimetableConfig(AppConfig):
     verbose_name = "Timetable"
 
     def ready(self):
-        """
-        this garanties that my signal are imported when I use the application.
-        """
+        """Ensure timetable signals are imported when the app is ready."""
         import app.timetable.signals  # noqa: F401

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -47,16 +47,12 @@ class Section(models.Model):
     # ---------- display helpers ----------
     @property
     def spaces(self) -> List[Room]:
-        """
-        Return a list of all Room instances in which this section meets.
-        """
+        """Return a list of all ``Room`` instances in which this section meets."""
         return [s.room for s in self.sessions.all() if s.room]
 
     @property
     def space_codes(self) -> str:
-        """
-        Return a comma-separated string of each Room’s code.
-        """
+        """Return a comma-separated string of each room’s code."""
         return ", ".join(room.code for room in self.spaces)
 
     @property

--- a/app/urls.py
+++ b/app/urls.py
@@ -1,7 +1,6 @@
-"""
-URL configuration for app project.
+"""URL configuration for app project.
 
-The `urlpatterns` list routes URLs to views. For more information please see:
+The ``urlpatterns`` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/5.2/topics/http/urls/
 Examples:
 Function views


### PR DESCRIPTION
## Summary
- add a package description to `app/__init__.py`
- tweak admin action docstring
- clean up docstrings in timetable widgets and models
- clarify URL config module docstring
- simplify `TimetableConfig.ready`

## Testing
- `ruff check app/__init__.py app/academics/admin/actions.py app/timetable/apps.py app/timetable/models/section.py app/timetable/admin/widgets/session.py app/timetable/admin/widgets/section.py app/urls.py`
- `python3 -m pytest -q` *(fails: Plugin already registered under a different name)*

------
https://chatgpt.com/codex/tasks/task_e_68533c16a1048323ac72d80bf107b5c9