### PR TITLE
Add structured logs for reservations and payments

### DIFF
--- a/app/academics/tests/__init__.py
+++ b/app/academics/tests/__init__.py
@@ -1,4 +1,5 @@
-"""Initialization for the tests academics package."""
+"""Initialization for the academics tests package."""
 
-# Reuse fixtures defined in the project-level ``tests.conftest`` module.
-pytest_plugins = ("tests.conftest",)
+# Fixtures are provided by the project-level ``tests.conftest`` module which
+# is automatically discovered by pytest. No explicit ``pytest_plugins`` is
+# required here.

--- a/app/finance/tests/__init__.py
+++ b/app/finance/tests/__init__.py
@@ -1,4 +1,4 @@
-"""Initialization for the tests finance package."""
+"""Initialization for the finance tests package."""
 
-# Reuse fixtures defined in the project-level ``tests.conftest`` module.
-pytest_plugins = ("tests.conftest",)
+# The project-level ``tests.conftest`` provides shared fixtures, automatically
+# loaded by pytest. No need to declare ``pytest_plugins`` here.

--- a/app/finance/tests/test_payment_history.py
+++ b/app/finance/tests/test_payment_history.py
@@ -2,8 +2,8 @@ import pytest
 from decimal import Decimal
 from app.finance.models import FinancialRecord, PaymentHistory
 
-# Reuse fixtures defined in the project-level ``tests.conftest`` module.
-pytest_plugins = ["tests.conftest"]
+# Fixtures from ``tests.conftest`` are automatically available; no explicit
+# ``pytest_plugins`` declaration is needed.
 
 
 @pytest.mark.django_db

--- a/app/settings.py
+++ b/app/settings.py
@@ -155,3 +155,31 @@ MEDIA_ROOT = BASE_DIR / "media/"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# --------------------------------------------------------------
+# Logging configuration
+# --------------------------------------------------------------
+LOG_DIR = BASE_DIR / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "format": '{"time": "%(asctime)s", "level": "%(levelname)s", '
+            '"name": "%(name)s", "message": %(message)s}',
+        },
+    },
+    "handlers": {
+        "actions": {
+            "class": "logging.FileHandler",
+            "filename": LOG_DIR / "actions.log",
+            "formatter": "json",
+        },
+    },
+    "root": {
+        "handlers": ["actions"],
+        "level": "INFO",
+    },
+}

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -3,6 +3,8 @@
 from datetime import timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING
+import json
+import logging
 
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
@@ -22,6 +24,8 @@ from app.timetable.models.validator import CreditLimitValidator
 
 if TYPE_CHECKING:
     from app.people.models.staffs import Staff
+
+logger = logging.getLogger(__name__)
 
 
 class Reservation(StatusableMixin, models.Model):
@@ -155,6 +159,18 @@ class Reservation(StatusableMixin, models.Model):
             amount=self.fee_total,
             method=PaymentMethod.CASH,
             recorded_by=by_user,
+        )
+
+        logger.info(
+            json.dumps(
+                {
+                    "action": "payment_recorded",
+                    "reservation": self.pk,
+                    "amount": str(self.fee_total),
+                    "method": PaymentMethod.CASH,
+                    "recorded_by": by_user.id,
+                }
+            )
         )
 
         fr, _ = FinancialRecord.objects.get_or_create(

--- a/app/timetable/services.py
+++ b/app/timetable/services.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 from typing import Iterable, List
+import json
+import logging
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -13,6 +15,8 @@ from django.utils import timezone
 from app.people.models import Student
 from app.shared.constants import MAX_STUDENT_CREDITS, StatusReservation
 from app.timetable.models import Reservation, Section
+
+logger = logging.getLogger(__name__)
 
 
 def reserve_sections(student: Student, sections: Iterable[Section]) -> List[Reservation]:
@@ -76,6 +80,16 @@ def reserve_sections(student: Student, sections: Iterable[Section]) -> List[Rese
                 section=sec,
                 status=StatusReservation.REQUESTED,
                 validation_deadline=timezone.now() + timedelta(days=2),
+            )
+            logger.info(
+                json.dumps(
+                    {
+                        "action": "reservation_created",
+                        "student": student.id,
+                        "section": sec.id,
+                        "reservation": res.id,
+                    }
+                )
             )
             Section.objects.filter(pk=sec.pk).update(
                 current_registrations=F("current_registrations") + 1


### PR DESCRIPTION
## Summary
- configure JSON logging and write output to `logs/actions.log`
- log new reservation actions in `reserve_sections`
- log payment events when reservations are paid
- clean up pytest plugin declarations in tests

## Testing
- `black app/ && flake8 app/ && mypy app/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68534cf6cf408323a8ed721ac9b4b90f