### PR TITLE
Centralize app choice enums

### DIFF
--- a/app/academics/admin/forms.py
+++ b/app/academics/admin/forms.py
@@ -8,7 +8,7 @@ from django.contrib import admin
 from django.contrib.admin.widgets import AutocompleteSelect
 from app.shared.utils import make_course_code
 from app.academics.models import Course, Curriculum, CurriculumCourse, College
-from app.shared.enums import CREDIT_NUMBER
+from app.academics.choices import CREDIT_NUMBER
 from import_export.forms import ImportForm
 
 

--- a/app/academics/choices.py
+++ b/app/academics/choices.py
@@ -1,0 +1,43 @@
+from django.db import models
+from django.db.models import IntegerChoices
+
+class CollegeCodeChoices(models.TextChoices):
+    COHS = "cohs", "COHS"
+    COAS = "coas", "COAS"
+    COED = "coed", "COED"
+    CAFS = "cafs", "CAFS"
+    COET = "coet", "COET"
+    COBA = "coba", "COBA"
+
+
+class CollegeLongNameChoices(models.TextChoices):
+    COHS = "cohs_long_name", "College of Health Sciences"
+    COAS = "coas_long_name", "College of Arts and Sciences"
+    COED = "coed_long_name", "College of Education"
+    CAFS = "cafs_long_name", "College of Agriculture and Food Sciences"
+    COET = "coet_long_name", "College of Engineering and Technology"
+    COBA = "coba_long_name", "College of Business Administration"
+
+
+class StatusCurriculum(models.TextChoices):
+    PENDING = "pending", "Pending"
+    APPROVED = "approved", "Approved"
+    NEEDS_REVISION = "needs_revision", "Needs Revision"
+
+
+class CREDIT_NUMBER(IntegerChoices):
+    ZERO = 0, "0"
+    ONE = 1, "1"
+    TWO = 2, "2"
+    THREE = 3, "3"
+    FOUR = 4, "4"
+    SIX = 6, "6"
+    TEN = 10, "10"
+
+
+class LEVEL_NUMBER(IntegerChoices):
+    ONE = 1, "freshman"
+    TWO = 2, "sophomore"
+    THREE = 3, "junior"
+    FOUR = 4, "senior"
+    FIVE = 5, "senior"

--- a/app/academics/models/college.py
+++ b/app/academics/models/college.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from app.shared.constants.academics import CollegeCodeChoices, CollegeLongNameChoices
+from app.academics.choices import CollegeCodeChoices, CollegeLongNameChoices
 
 
 class College(models.Model):

--- a/app/academics/models/course.py
+++ b/app/academics/models/course.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django.db import models
 
-from app.shared.enums import CREDIT_NUMBER, LEVEL_NUMBER
+from app.academics.choices import CREDIT_NUMBER, LEVEL_NUMBER
 from app.shared.utils import make_course_code
 from app.academics.models.curriculum import Curriculum
 

--- a/app/academics/models/curriculum.py
+++ b/app/academics/models/curriculum.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from datetime import date
 
-from app.shared.constants.academics import StatusCurriculum
+from app.academics.choices import StatusCurriculum
 from django.db import models
 
 from app.shared.mixins import StatusableMixin

--- a/app/academics/models/curriculum_course.py
+++ b/app/academics/models/curriculum_course.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django.db import models
 
-from app.shared.enums import CREDIT_NUMBER
+from app.academics.choices import CREDIT_NUMBER
 
 
 class CurriculumCourse(models.Model):

--- a/app/finance/choices.py
+++ b/app/finance/choices.py
@@ -1,0 +1,23 @@
+from django.db import models
+
+class StatusClearance(models.TextChoices):
+    PENDING = "pending", "Pending"
+    CLEARED = "cleared", "Cleared"
+    BLOCKED = "blocked", "Blocked"
+
+
+class PaymentMethod(models.TextChoices):
+    CASH = "cash", "Cash"
+    CRYPTO = "crypto", "Crypto (ADA)"
+    MOBILE_MONEY = "mobile_money", "Mobile Money"
+    WIRE = "wire", "Wire"
+
+
+class FeeType(models.TextChoices):
+    """Enumeration of fee types."""
+
+    CREDIT_HOUR_FEE = "CREDIT_HOUR_FEE", "Credit Hour Fee"
+    LAB = "lab", "Lab"
+    OTHER = "other", "Other"
+    RESEARCH = "research", "Research"
+    TUITION = "tuition", "Tuition"

--- a/app/finance/models/financial_record.py
+++ b/app/finance/models/financial_record.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django.db import models
 
-from app.shared.constants.finance import FeeType, StatusClearance
+from app.finance.choices import FeeType, StatusClearance
 
 
 class FinancialRecord(models.Model):
@@ -37,7 +37,7 @@ class FinancialRecord(models.Model):
     clearance_status = models.CharField(
         max_length=50,
         choices=StatusClearance.choices,
-        default="pending",
+        default=StatusClearance.PENDING,
     )
     last_updated = models.DateTimeField(auto_now=True)
     verified_by = models.ForeignKey(

--- a/app/finance/models/payment.py
+++ b/app/finance/models/payment.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django.db import models
 
-from app.shared.constants import PaymentMethod
+from app.finance.choices import PaymentMethod
 
 
 class Payment(models.Model):

--- a/app/people/choices.py
+++ b/app/people/choices.py
@@ -1,0 +1,18 @@
+from django.db import models
+
+class UserRole(models.TextChoices):
+    STUDENT = "student", "Student"
+    PROSPECTIVE_STUDENT = "prospective_student", "Prospective Student"
+    TECHNICIAN = "technician", "Technician"
+    LAB_TECHNICIAN = "lab_technician", "Lab Technician"
+    REGISTRAR = "registrar", "Registrar"
+    ENROLLMENT_OFFICER = "enrollment_officer", "Enrollment Officer"
+    DEAN = "dean", "Dean"
+    CHAIR = "chair", "Chair"
+    LECTURER = "lecturer", "Lecturer"
+    ASSISTANT_PROFESSOR = "assistant_professor", "Assistant Professor"
+    ASSOCIATE_PROFESSOR = "associate_professor", "Associate Professor"
+    PROFESSOR = "professor", "Professor"
+    FACULTY = "faculty", "Faculty"
+    VPAA = "vpaa", "Vpaa"
+    FINANCIALOFFICER = "financial_officer", "Financial Officer"

--- a/app/people/models/role_assignment.py
+++ b/app/people/models/role_assignment.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from django.contrib.auth import get_user_model
 from django.db import models
 
-from app.shared.constants.perms import UserRole
+from app.people.choices import UserRole
 
 User = get_user_model()
 

--- a/app/registry/choices.py
+++ b/app/registry/choices.py
@@ -1,0 +1,21 @@
+from django.db import models
+
+class DocumentType(models.TextChoices):
+    WAEC = "waec", "Waec"
+    BILL = "bill", "Bill"
+    TRANSCRIPT = "transcript", "Transcript"
+    PUBLIC = "public", "Public_signature"
+
+
+class StatusRegistration(models.TextChoices):
+    PENDING = "pending payment", "Pending Payment"
+    FINANCIALLY_CLEARED = "financially_cleared", "Financially_Cleared"
+    COMPLETED = "completed", "Completed"
+    APPROVED = "approved", "Approved"
+
+
+class StatusDocument(models.TextChoices):
+    PENDING = "pending", "Pending"
+    APPROVED = "approved", "Approved"
+    ADJUSTMENTS_REQUIRED = "adjustments_required", "Adjustments Required"
+    REJECTED = "rejected", "Rejected"

--- a/app/registry/models/class_roster.py
+++ b/app/registry/models/class_roster.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models import QuerySet
 
 from app.people.models import Student
-from app.shared.constants import StatusRegistration
+from app.registry.choices import StatusRegistration
 
 
 class ClassRoster(models.Model):

--- a/app/registry/models/document.py
+++ b/app/registry/models/document.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
-from app.shared.constants import DocumentType, StatusDocument
+from app.registry.choices import DocumentType, StatusDocument
 from app.shared.mixins import StatusableMixin, StatusHistory
 
 

--- a/app/registry/models/registration.py
+++ b/app/registry/models/registration.py
@@ -7,7 +7,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
 
-from app.shared.constants import StatusRegistration
+from app.registry.choices import StatusRegistration
 from app.shared.mixins import StatusableMixin
 from app.timetable.models import Reservation
 

--- a/app/shared/constants/__init__.py
+++ b/app/shared/constants/__init__.py
@@ -3,30 +3,17 @@
 from itertools import chain
 from typing import List, Tuple
 
-from app.shared.constants.timetable import StatusReservation
+from app.timetable.choices import StatusReservation
 
-from .academics import (
-    CollegeCodeChoices,
-    COURSE_PATTERN,
-    MAX_STUDENT_CREDITS,
-    StatusCurriculum,
-)
+from .academics import COURSE_PATTERN, MAX_STUDENT_CREDITS
+from app.academics.choices import CollegeCodeChoices, StatusCurriculum
 from .curriculum import TEST_ENVIRONMENTAL_STUDIES_CURRICULUM
-from .finance import (
-    TUITION_RATE_PER_CREDIT,
-    FeeType,
-    PaymentMethod,
-    StatusClearance,
-)
+from .finance import TUITION_RATE_PER_CREDIT
+from app.finance.choices import FeeType, PaymentMethod, StatusClearance
 
-from .perms import (
-    DEFAULT_ROLE_TO_COLLEGE,
-    MODEL_APP,
-    OBJECT_PERM_MATRIX,
-    TEST_PW,
-    UserRole,
-)
-from .registry import DocumentType, StatusDocument, StatusRegistration
+from .perms import DEFAULT_ROLE_TO_COLLEGE, MODEL_APP, OBJECT_PERM_MATRIX, TEST_PW
+from app.people.choices import UserRole
+from app.registry.choices import DocumentType, StatusDocument, StatusRegistration
 
 STYLE_DEFAULT = "NOTICE"
 

--- a/app/shared/constants/academics.py
+++ b/app/shared/constants/academics.py
@@ -6,8 +6,14 @@ curricula. It exposes the ``COURSE_PATTERN`` regular expression, maximum
 credit load for a student and enumerations for colleges and curriculum
 statuses."""
 
-from django.db import models
 import re
+from app.academics.choices import (
+    CollegeCodeChoices,
+    CollegeLongNameChoices,
+    StatusCurriculum,
+    CREDIT_NUMBER,
+    LEVEL_NUMBER,
+)
 
 MAX_STUDENT_CREDITS = 18
 COURSE_PATTERN = re.compile(
@@ -15,25 +21,3 @@ COURSE_PATTERN = re.compile(
 )
 
 
-class CollegeCodeChoices(models.TextChoices):
-    COHS = "cohs", "COHS"
-    COAS = "coas", "COAS"
-    COED = "coed", "COED"
-    CAFS = "cafs", "CAFS"
-    COET = "coet", "COET"
-    COBA = "coba", "COBA"
-
-
-class CollegeLongNameChoices(models.TextChoices):
-    COHS = "cohs_long_name", "College of Health Sciences"
-    COAS = "coas_long_name", "College of Arts and Sciences"
-    COED = "coed_long_name", "College of Education"
-    CAFS = "cafs_long_name", "College of Agriculture and Food Sciences"
-    COET = "coet_long_name", "College of Engineering and Technology"
-    COBA = "coba_long_name", "College of Business Administration"
-
-
-class StatusCurriculum(models.TextChoices):
-    PENDING = "pending", "Pending"
-    APPROVED = "approved", "Approved"
-    NEEDS_REVISION = "needs_revision", "Needs Revision"

--- a/app/shared/constants/finance.py
+++ b/app/shared/constants/finance.py
@@ -6,30 +6,7 @@ clearance statuses.  It also exposes the ``TUITION_RATE_PER_CREDIT``
 value used when computing tuition."""
 
 from decimal import Decimal
-from django.db import models
-
-
-class StatusClearance(models.TextChoices):
-    PENDING = "pending", "Pending"
-    CLEARED = "cleared", "Cleared"
-    BLOCKED = "blocked", "Blocked"
-
-
-class PaymentMethod(models.TextChoices):
-    CASH = "cash", "Cash"
-    CRYPTO = "crypto", "Crypto (ADA)"
-    MOBILE_MONEY = "mobile_money", "Mobile Money"
-    WIRE = "wire", "Wire"
-
-
-class FeeType(models.TextChoices):
-    """Enumeration of fee types."""
-
-    CREDIT_HOUR_FEE = "CREDIT_HOUR_FEE", "Credit Hour Fee"
-    LAB = "lab", "Lab"
-    OTHER = "other", "Other"
-    RESEARCH = "research", "Research"
-    TUITION = "tuition", "Tuition"
+from app.finance.choices import FeeType, PaymentMethod, StatusClearance
 
 
 TUITION_RATE_PER_CREDIT = Decimal("5.00")

--- a/app/shared/constants/perms.py
+++ b/app/shared/constants/perms.py
@@ -7,25 +7,9 @@ help the permissions middleware resolve context information."""
 
 from django.db import models
 
+from app.people.choices import UserRole
+
 TEST_PW = "test"
-
-
-class UserRole(models.TextChoices):
-    STUDENT = "student", "Student"
-    PROSPECTIVE_STUDENT = "prospective_student", "Prospective Student"
-    TECHNICIAN = "technician", "Technician"
-    LAB_TECHNICIAN = "lab_technician", "Lab Technician"
-    REGISTRAR = "registrar", "Registrar"
-    ENROLLMENT_OFFICER = "enrollment_officer", "Enrollment Officer"
-    DEAN = "dean", "Dean"
-    CHAIR = "chair", "Chair"
-    LECTURER = "lecturer", "Lecturer"
-    ASSISTANT_PROFESSOR = "assistant_professor", "Assistant Professor"
-    ASSOCIATE_PROFESSOR = "associate_professor", "Associate Professor"
-    PROFESSOR = "professor", "Professor"
-    FACULTY = "faculty", "Faculty"
-    VPAA = "vpaa", "Vpaa"
-    FINANCIALOFFICER = "financial_officer", "Financial Officer"
 
 
 DEFAULT_ROLE_TO_COLLEGE = {

--- a/app/shared/constants/registry.py
+++ b/app/shared/constants/registry.py
@@ -3,25 +3,8 @@
 This module enumerates document types that can be uploaded by students as
 well as the possible statuses for both registrations and documents."""
 
-from django.db import models
-
-
-class DocumentType(models.TextChoices):
-    WAEC = "waec", "Waec"
-    BILL = "bill", "Bill"
-    TRANSCRIPT = "transcript", "Transcript"
-    PUBLIC = "public", "Public_signature"
-
-
-class StatusRegistration(models.TextChoices):
-    PENDING = "pending payment", "Pending Payment"
-    FINANCIALLY_CLEARED = "financially_cleared", "Financially_Cleared"
-    COMPLETED = "completed", "Completed"
-    APPROVED = "approved", "Approved"
-
-
-class StatusDocument(models.TextChoices):
-    PENDING = "pending", "Pending"
-    APPROVED = "approved", "Approved"
-    ADJUSTMENTS_REQUIRED = "adjustments_required", "Adjustments Required"
-    REJECTED = "rejected", "Rejected"
+from app.registry.choices import (
+    DocumentType,
+    StatusDocument,
+    StatusRegistration,
+)

--- a/app/shared/constants/timetable.py
+++ b/app/shared/constants/timetable.py
@@ -3,11 +3,4 @@
 Currently this includes the :class:`StatusReservation` enumeration used to
 track the life cycle of a student's reservation of a section."""
 
-from django.db import models
-
-
-class StatusReservation(models.TextChoices):
-    CANCELLED = "cancelled", "Cancelled"
-    PAID = "paid", "Paid"
-    REQUESTED = "requested", "Requested"
-    VALIDATED = "validated", "Validated"
+from app.timetable.choices import StatusReservation

--- a/app/shared/management/populate_helpers/auth.py
+++ b/app/shared/management/populate_helpers/auth.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from app.academics.models import College
 from app.people.models import RoleAssignment
 from app.shared.constants import DEFAULT_ROLE_TO_COLLEGE, TEST_PW
-from app.shared.constants.perms import UserRole
+from app.people.choices import UserRole
 
 from .utils import log
 

--- a/app/timetable/admin/widgets/session.py
+++ b/app/timetable/admin/widgets/session.py
@@ -2,7 +2,7 @@
 
 from import_export import widgets
 
-from app.shared.enums import WEEKDAYS_NUMBER
+from app.timetable.choices import WEEKDAYS_NUMBER
 from app.spaces.admin.widgets import RoomCodeWidget
 from app.timetable.models.session import Schedule, Session
 

--- a/app/timetable/choices.py
+++ b/app/timetable/choices.py
@@ -1,6 +1,11 @@
-"""Enums module."""
-
+from django.db import models
 from django.db.models import IntegerChoices
+
+class StatusReservation(models.TextChoices):
+    CANCELLED = "cancelled", "Cancelled"
+    PAID = "paid", "Paid"
+    REQUESTED = "requested", "Requested"
+    VALIDATED = "validated", "Validated"
 
 
 class SEMESTER_NUMBER(IntegerChoices):
@@ -13,24 +18,6 @@ class SEMESTER_NUMBER(IntegerChoices):
 class TERM_NUMBER(IntegerChoices):
     FIRST = 1, "First"
     SECOND = 2, "Second"
-
-
-class CREDIT_NUMBER(IntegerChoices):
-    ZERO = 0, "0"
-    ONE = 1, "1"
-    TWO = 2, "2"
-    THREE = 3, "3"
-    FOUR = 4, "4"
-    SIX = 6, "6"
-    TEN = 10, "10"
-
-
-class LEVEL_NUMBER(IntegerChoices):
-    ONE = 1, "freshman"
-    TWO = 2, "sophomore"
-    THREE = 3, "junior"
-    FOUR = 4, "senior"
-    FIVE = 5, "senior"
 
 
 class WEEKDAYS_NUMBER(IntegerChoices):

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -10,12 +10,9 @@ from django.db.models import F
 from django.utils import timezone
 
 from app.finance.models import FinancialRecord, Payment, SectionFee
-from app.shared.constants import (
-    MAX_STUDENT_CREDITS,
-    TUITION_RATE_PER_CREDIT,
-    PaymentMethod,
-    StatusReservation,
-)
+from app.shared.constants import MAX_STUDENT_CREDITS, TUITION_RATE_PER_CREDIT
+from app.finance.choices import PaymentMethod
+from app.timetable.choices import StatusReservation
 from app.shared.mixins import StatusableMixin
 from app.timetable.models.section import Section
 from app.timetable.models.validator import CreditLimitValidator

--- a/app/timetable/models/semester.py
+++ b/app/timetable/models/semester.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from django.db import models
-from app.shared.enums import SEMESTER_NUMBER
+from app.timetable.choices import SEMESTER_NUMBER
 from app.timetable.utils import validate_subperiod
 
 

--- a/app/timetable/models/session.py
+++ b/app/timetable/models/session.py
@@ -5,7 +5,7 @@ from datetime import datetime, time, timedelta
 from django.db import models, transaction
 from django.forms import ValidationError
 
-from app.shared.enums import WEEKDAYS_NUMBER
+from app.timetable.choices import WEEKDAYS_NUMBER
 
 
 class Schedule(models.Model):

--- a/app/timetable/models/term.py
+++ b/app/timetable/models/term.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from django.db import models
 
-from app.shared.enums import TERM_NUMBER
+from app.timetable.choices import TERM_NUMBER
 from app.timetable.utils import validate_subperiod
 
 

--- a/app/timetable/signals.py
+++ b/app/timetable/signals.py
@@ -8,7 +8,7 @@ from django.dispatch import receiver
 from django.db.models import F
 
 from app.timetable.models import Section, Reservation
-from app.shared.constants import StatusReservation
+from app.timetable.choices import StatusReservation
 
 
 @receiver(pre_save, sender=Section)

--- a/app/timetable/tasks.py
+++ b/app/timetable/tasks.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from django.db import transaction
 from django.db.models import F
 from app.timetable.models import Reservation, Section
-from app.shared.constants import StatusReservation
+from app.timetable.choices import StatusReservation
 
 
 def cancel_expired_reservations():

--- a/app/timetable/tests/test_weekdays_enum.py
+++ b/app/timetable/tests/test_weekdays_enum.py
@@ -1,6 +1,6 @@
 """Test weekdays enum module."""
 
-from app.shared.enums import WEEKDAYS_NUMBER
+from app.timetable.choices import WEEKDAYS_NUMBER
 
 
 def test_monday_is_one():

--- a/app/website/views.py
+++ b/app/website/views.py
@@ -17,7 +17,7 @@ from app.finance.models.financial_record import FinancialRecord
 from app.people.models.student import Student
 from app.registry.models.grade import Grade
 from app.registry.models.registration import Registration
-from app.shared.constants import StatusReservation
+from app.timetable.choices import StatusReservation
 from app.timetable.models import Reservation, Section
 
 
@@ -123,7 +123,8 @@ def validate_credit_limit(
     """Return ``True`` if adding ``section`` keeps the student under ``max_credits``."""
     reserved_credits = (
         Reservation.objects.filter(
-            student=student, status__in=["requested", "validated"]
+            student=student,
+            status__in=[StatusReservation.REQUESTED, StatusReservation.VALIDATED],
         ).aggregate(total=Sum("section__course__credit_hours"))["total"]
         or 0
     )


### PR DESCRIPTION
## Summary
- add choices.py for academics, finance, people, registry and timetable apps
- reference new choice enums across models and views
- drop old shared `enums.py` and import choices from new modules
- replace hardcoded statuses with enums

## Testing
- `codo-tuth-env/bin/python -m pytest -q` *(fails: Plugin already registered)*

------
https://chatgpt.com/codex/tasks/task_e_68534d2a6adc83238c1db9632cb71428