### PR TITLE
Improve data validation

### DIFF
--- a/app/people/models/staffs.py
+++ b/app/people/models/staffs.py
@@ -5,6 +5,7 @@
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.models import QuerySet
+from django.core.exceptions import ValidationError
 
 from app.academics.models.college import College
 from app.academics.models.curriculum import Curriculum
@@ -62,9 +63,8 @@ class Faculty(StatusableMixin, models.Model):
         return f"{self.staff_profile}"
 
     def save(self, *args, **kwargs):
-        assert (
-            self.staff_profile is not None
-        ), "Staff profil must be save before the Faculty. Check"
+        if self.staff_profile is None:
+            raise ValidationError("Staff profile must be saved before the Faculty.")
         try:
             _ = self.college
         except College.DoesNotExist:

--- a/app/shared/forms.py
+++ b/app/shared/forms.py
@@ -34,7 +34,8 @@ class StatusHistoryForm(forms.ModelForm):
         if content_type:
 
             field = self.fields["state"]
-            assert isinstance(field, ChoiceField)
+            if not isinstance(field, ChoiceField):
+                raise TypeError("state field must be a ChoiceField")
             model_cls = content_type.model_class()
             if model_cls:
                 try:

--- a/app/shared/utils.py
+++ b/app/shared/utils.py
@@ -29,10 +29,12 @@ def expand_course_code(
         The department code, course number and college code.
     """
 
-    assert "/" not in code
+    if "/" in code:
+        raise ValueError("Course code cannot contain '/' characters.")
 
     match = COURSE_PATTERN.search(code.strip().upper())
-    assert match is not None, f"Code '{code}' doesn't match expected pattern"
+    if match is None:
+        raise ValueError(f"Code '{code}' doesn't match expected pattern")
 
     dept, num, college = (
         match.group("dept"),

--- a/app/timetable/admin/widgets/core.py
+++ b/app/timetable/admin/widgets/core.py
@@ -2,6 +2,7 @@
 
 import re
 from datetime import date
+from django.core.exceptions import ValidationError
 
 from import_export import widgets
 
@@ -42,7 +43,8 @@ class AcademicYearCodeWidget(widgets.ForeignKeyWidget):
 
         m = self.ay_pat.match(value)
 
-        assert m, f"Invalid academic year short name, but got {m} for {self.ay_pat}"
+        if not m:
+            raise ValidationError(f"Invalid academic year short name, but got {value}")
 
         start_year = int("20" + m.group(1))
         ay, ay_created = AcademicYear.objects.get_or_create(
@@ -105,7 +107,8 @@ class SemesterCodeWidget(widgets.ForeignKeyWidget):
 
         m = self.sem_pat.match(value)
 
-        assert m, f"Invalid semester format, got {m} for {self.sem_pat}"
+        if not m:
+            raise ValidationError(f"Invalid semester format: {value}")
 
         ay_short = m.group("year")
         sem_no = int(m.group("num"))

--- a/app/timetable/admin/widgets/session.py
+++ b/app/timetable/admin/widgets/session.py
@@ -1,6 +1,7 @@
 """timetable.admin.widgets.session module"""
 
 from import_export import widgets
+from django.core.exceptions import ValidationError
 
 from app.shared.enums import WEEKDAYS_NUMBER
 from app.spaces.admin.widgets import RoomCodeWidget
@@ -73,6 +74,7 @@ class WeekdayWidget(widgets.IntegerWidget):
             return int(token)
 
         _map = {label.lower(): num for num, label in WEEKDAYS_NUMBER.choices}
-        assert token in _map, f"{token} is not in {_map}"
+        if token not in _map:
+            raise ValidationError(f"{token} is not in {_map}")
 
         return _map[token]

--- a/app/timetable/models/academic_year.py
+++ b/app/timetable/models/academic_year.py
@@ -29,9 +29,9 @@ class AcademicYear(models.Model):
         """Ensure start and end dates form a valid academic year."""
         if self.start_date.month not in (7, 8, 9, 10):
             raise ValidationError("Start date must be in July–October.")
-        if self.start_date:
-            if self.end_date:
-                assert self.end_date.year > self.start_date.year
+        if self.start_date and self.end_date:
+            if self.end_date.year <= self.start_date.year:
+                raise ValidationError("end_date must be in the following year")
 
     def save(self, *args, **kwargs) -> None:
         """Populate derived fields ``long_name`` and ``code`` before saving."""
@@ -57,6 +57,10 @@ class AcademicYear(models.Model):
             models.UniqueConstraint(
                 ExtractYear("start_date"),
                 name="uniq_academic_year_by_year",
-            )
+            ),
+            models.CheckConstraint(
+                check=models.Q(end_date__gt=models.F("start_date")),
+                name="end_date_after_start_date",
+            ),
         ]
         ordering = ["-start_date"]

--- a/app/timetable/models/reservation.py
+++ b/app/timetable/models/reservation.py
@@ -134,9 +134,8 @@ class Reservation(StatusableMixin, models.Model):
 
     def cancel(self) -> None:
         """Cancel the reservation and free a seat in the section."""
-        assert (
-            self.status != StatusReservation.CANCELLED
-        ), "Reservation already cancelled."
+        if self.status == StatusReservation.CANCELLED:
+            raise ValueError("Reservation already cancelled.")
         self.status = StatusReservation.CANCELLED
 
         self.save(update_fields=["status"])

--- a/app/timetable/models/session.py
+++ b/app/timetable/models/session.py
@@ -92,8 +92,9 @@ class Schedule(models.Model):
     # and implement a non overlap function like for semester and terms.
     def clean(self) -> None:
         """Check that the date are correct"""
-        if self.end_time is not None:
-            assert self.start_time < self.end_time, "start_time must be before end_time"
+        if self.end_time is not None and self.start_time:
+            if self.start_time >= self.end_time:
+                raise ValidationError("start_time must be before end_time")
 
     def save(self, *args, **kwargs):
         """
@@ -120,6 +121,12 @@ class Schedule(models.Model):
 
     class Meta:
         ordering = ["weekday", "start_time", "end_time"]
+        constraints = [
+            models.CheckConstraint(
+                check=models.Q(end_time__gt=models.F("start_time")),
+                name="schedule_end_after_start",
+            )
+        ]
 
 
 class Session(models.Model):

--- a/app/timetable/models/term.py
+++ b/app/timetable/models/term.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from django.db import models
+from django.core.exceptions import ValidationError
 
 from app.shared.enums import TERM_NUMBER
 from app.timetable.utils import validate_subperiod
@@ -28,7 +29,8 @@ class Term(models.Model):
         """Validate dates are inside the parent semester and do not overlap."""
         container_start = self.semester.start_date
         container_end = self.semester.end_date
-        assert container_start is not None and container_end is not None
+        if container_start is None or container_end is None:
+            raise ValidationError("Parent semester must have start and end dates")
 
         validate_subperiod(
             sub_start=self.start_date,


### PR DESCRIPTION
## Summary
- enforce data constraints with `ValidationError` and `CheckConstraint`
- drop assert-based checks in widgets and models

## Testing
- `black app/people/models/core.py app/people/models/staffs.py app/shared/utils.py app/shared/forms.py app/timetable/admin/widgets/session.py app/timetable/admin/widgets/core.py app/timetable/models/academic_year.py app/timetable/models/section.py app/timetable/models/session.py app/timetable/models/reservation.py app/timetable/models/term.py`
- `flake8 --max-line-length=90 app/people/models/staffs.py app/people/models/core.py app/shared/utils.py app/shared/forms.py app/timetable/admin/widgets/session.py app/timetable/admin/widgets/core.py app/timetable/models/academic_year.py app/timetable/models/section.py app/timetable/models/session.py app/timetable/models/reservation.py app/timetable/models/term.py`
- `mypy --config-file /tmp/mypy.ini app/people/models/staffs.py app/people/models/core.py app/shared/utils.py app/shared/forms.py app/timetable/admin/widgets/session.py app/timetable/admin/widgets/core.py app/timetable/models/academic_year.py app/timetable/models/section.py app/timetable/models/session.py app/timetable/models/reservation.py app/timetable/models/term.py` *(fails: No module named 'mypy_django_plugin')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68534d9a29908323939c2617dfa125de