### PR TITLE
Add query type aliases

### DIFF
--- a/app/academics/models/course.py
+++ b/app/academics/models/course.py
@@ -4,6 +4,7 @@ from django.db import models
 
 from app.shared.enums import CREDIT_NUMBER, LEVEL_NUMBER
 from app.shared.utils import make_course_code
+from app.shared.types import CourseQuery
 
 
 class Course(models.Model):
@@ -53,7 +54,7 @@ class Course(models.Model):
             return "other"
 
     @classmethod
-    def for_curriculum(cls, curriculum) -> models.QuerySet:
+    def for_curriculum(cls, curriculum) -> CourseQuery:
         """Return courses included in the given curriculum."""
         return cls.objects.filter(curricula=curriculum).distinct()
 

--- a/app/registry/models/class_roster.py
+++ b/app/registry/models/class_roster.py
@@ -3,7 +3,7 @@ from __future__ import (
 )
 
 from django.db import models
-from django.db.models import QuerySet
+from app.shared.types import StudentProfileQuery
 
 from app.people.models.profile import StudentProfile
 from app.shared.constants import StatusRegistration
@@ -16,7 +16,7 @@ class ClassRoster(models.Model):
     last_updated = models.DateTimeField(auto_now=True)
 
     @property
-    def students(self) -> QuerySet[StudentProfile]:
+    def students(self) -> StudentProfileQuery:
         """Return all users registered to this section."""
         return StudentProfile.objects.filter(
             student_registrations__section=self.section,

--- a/app/shared/types.py
+++ b/app/shared/types.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+from django.db.models import QuerySet
+
+if TYPE_CHECKING:
+    from app.timetable.models import Section
+    from app.academics.models import Course
+    from app.people.models.profile import StudentProfile
+
+SectionQuery: TypeAlias = QuerySet["Section"]
+CourseQuery: TypeAlias = QuerySet["Course"]
+StudentProfileQuery: TypeAlias = QuerySet["StudentProfile"]

--- a/app/timetable/services.py
+++ b/app/timetable/services.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import List
+
+from app.shared.types import SectionQuery
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -9,11 +11,11 @@ from django.db.models import Sum
 from app.people.models import StudentProfile
 from app.shared.constants import MAX_STUDENT_CREDITS
 from app.shared.constants.finance import StatusReservation
-from app.timetable.models import Reservation, Section
+from app.timetable.models import Reservation
 
 
 def reserve_sections(
-    student: StudentProfile, sections: Iterable[Section]
+    student: StudentProfile, sections: SectionQuery
 ) -> List[Reservation]:
     """Create reservation objects for ``student`` on each section.
 


### PR DESCRIPTION
## Summary
- introduce shared type aliases for common QuerySets
- use these aliases in services and model helpers
- remove an unused import in services

## Testing
- `flake8 app/shared/types.py app/academics/models/course.py app/registry/models/class_roster.py app/timetable/services.py`
- `mypy app`

------
https://chatgpt.com/codex/tasks/task_e_685b255f358483239f530af93865e2db