### PR TITLE
Add grade inline

### DIFF
--- a/app/registry/admin/__init__.py
+++ b/app/registry/admin/__init__.py
@@ -1,5 +1,6 @@
 """Initialization for the registry admin package."""
 
 from .core import GradeAdmin, ClassRosterAdmin
+from .inlines import GradeInline
 
-__all__ = ["GradeAdmin", "ClassRosterAdmin"]
+__all__ = ["GradeAdmin", "ClassRosterAdmin", "GradeInline"]

--- a/app/registry/admin/inlines.py
+++ b/app/registry/admin/inlines.py
@@ -1,0 +1,17 @@
+"""Inlines for the registry admin interface."""
+
+from django.contrib import admin
+
+from app.registry.models.grade import Grade
+
+
+class GradeInline(admin.TabularInline):
+    """Inline editor for :class:`~app.registry.models.Grade` records."""
+
+    model = Grade
+    fk_name = "section"
+    extra = 0
+    fields = ("student", "letter_grade", "numeric_grade", "graded_on")
+    readonly_fields = ("graded_on",)
+    autocomplete_fields = ("student",)
+

--- a/app/timetable/admin/registers/section.py
+++ b/app/timetable/admin/registers/section.py
@@ -5,6 +5,7 @@ from guardian.admin import GuardedModelAdmin
 from import_export.admin import ImportExportModelAdmin
 
 from app.timetable.admin.inlines import SessionInline
+from app.registry.admin.inlines import GradeInline
 from app.timetable.admin.resources.section import SectionResource
 from app.timetable.models.section import Section
 
@@ -20,7 +21,7 @@ class SectionAdmin(ImportExportModelAdmin, GuardedModelAdmin):
     # ! TODO ajouter à la list, les rooms occupé et le nombre de sessions, le nombre de crédits
     resource_class = SectionResource
     list_display = ("semester", "program", "number", "faculty", "available_seats")
-    inlines = [SessionInline]
+    inlines = [SessionInline, GradeInline]
     list_filter = ("program__curriculum",)
     autocomplete_fields = ("semester", "faculty")
 

--- a/tests/registry/test_grade_inline.py
+++ b/tests/registry/test_grade_inline.py
@@ -1,0 +1,36 @@
+"""Tests for grade entry inline."""
+
+import pytest
+from django.urls import reverse
+from django.contrib import admin
+
+from app.timetable.models.section import Section
+from app.timetable.admin.registers.section import SectionAdmin
+from app.registry.admin.inlines import GradeInline
+from app.academics.models.program import Program
+from app.academics.models.course import Course
+
+
+@pytest.mark.django_db
+def test_section_admin_has_grade_inline():
+    admin_obj = SectionAdmin(Section, admin.site)
+    assert GradeInline in admin_obj.inlines
+
+
+@pytest.mark.django_db
+def test_grade_inline_visible(admin_client, curriculum, semester):
+    course = Course.get_unique_default()
+    program = Program.objects.create(curriculum=curriculum, course=course)
+    section = Section.objects.create(
+        program=program,
+        semester=semester,
+        number=1,
+        start_date=semester.start_date,
+        end_date=semester.end_date,
+        max_seats=30,
+    )
+
+    url = reverse("admin:timetable_section_change", args=[section.pk])
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    assert "grade_set" in response.content.decode()


### PR DESCRIPTION
## Summary
- register `GradeInline` admin class
- embed new inline into `SectionAdmin`
- test grade inline visibility in admin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da9074790832399043acaca6149d2