### PR TITLE
Add admin filters and student course logic

### DIFF
--- a/app/academics/admin/widgets.py
+++ b/app/academics/admin/widgets.py
@@ -16,7 +16,7 @@ class ProgramWidget(widgets.ForeignKeyWidget):
     """Create or Program from CSV rows.
 
     Use the curriculum_short name as the 'value'.
-    The widget delegates curriculum parsong to CurriculumWidget and course parsing
+    The widget delegates curriculum parsing to CurriculumWidget and course parsing
     to CourseWidget then assembles a Program object from the results.
     """
 

--- a/app/academics/models/curriculum.py
+++ b/app/academics/models/curriculum.py
@@ -17,9 +17,8 @@ class Curriculum(StatusableMixin, models.Model):
         >>> col = College.objects.create(code="COAS", long_name="Arts and Sciences")
         >>> Curriculum.objects.create(short_name="BSCS", college=col)
 
-    We use a default curriculm incompassing all the courses for non specified
-    curriculum, otherwize the student should be limited to the courses listed
-    in their curriculum.
+    We use a default curriculum encompassing all courses when none is specified;
+    otherwise the student is limited to the courses listed in their curriculum.
     """
 
     short_name = models.CharField(max_length=40)

--- a/app/academics/models/department.py
+++ b/app/academics/models/department.py
@@ -22,11 +22,11 @@ class Department(models.Model):
     )
 
     def __str__(self) -> str:  # pragma: no cover
-        """The Department common represenation. ! This is not unique."""
+        """The Department common representation. This is not unique."""
         return self.code
 
     def _ensure_code(self) -> None:
-        """Builds a unique deparment code from short_name and college."""
+        """Build a unique department code from short_name and college."""
         if not self.code:
             self.code = f"{self.college}-{self.short_name}"
 

--- a/app/people/models/staffs.py
+++ b/app/people/models/staffs.py
@@ -58,7 +58,7 @@ class Staff(AbstractPerson):
             staff_id=f"DFT_STF{staff_id:04d}",
             user=get_default_user(),
             employment_date=date.today(),
-            deparment=Department.get_default(),
+            department=Department.get_default(),
             position=f"Joker {staff_id:04d}",
         )
         return dft_staff
@@ -125,7 +125,7 @@ class Faculty(StatusableMixin, models.Model):
     def save(self, *args, **kwargs):
         """Check that we have a college for the staff before save."""
         if self.staff_profile is None:
-            raise ValidationError("Staff profil must be save before the Faculty's")
+            raise ValidationError("Staff profile must be saved before the Faculty")
 
         self._ensure_college()
         super().save(*args, **kwargs)

--- a/app/people/models/student.py
+++ b/app/people/models/student.py
@@ -5,8 +5,13 @@
 from __future__ import annotations
 
 from app.academics.models.curriculum import Curriculum
+from app.academics.models.course import Course
+from app.academics.models.prerequisite import Prerequisite
 from app.people.models.core import AbstractPerson
+from app.registry.models.grade import Grade
 from django.db import models
+
+from app.shared.types import CourseQuery
 
 
 from app.timetable.models.semester import Semester
@@ -51,8 +56,30 @@ class Student(AbstractPerson):
     #     self.courses.credit
     @property
     def college(self):
-        """Retunrs the Student current college."""
+        """Return the student's current college."""
         self.curriculum.college
+
+    def passed_courses(self) -> CourseQuery:
+        """Return courses the student completed with a passing grade."""
+        return Course.objects.filter(
+            in_programs__sections__grade__student=self,
+            in_programs__sections__grade__numeric_grade__gte=60,
+        ).distinct()
+
+    def allowed_courses(self) -> CourseQuery:
+        """Return courses available for registration based on prerequisites."""
+        curriculum = self.curriculum or Curriculum.get_default()
+        all_courses = Course.for_curriculum(curriculum)
+        passed = self.passed_courses()
+        allowed_ids: list[int] = []
+        passed_ids = set(passed.values_list("id", flat=True))
+        for course in all_courses.exclude(id__in=passed_ids):
+            req_ids = course.course_prereq_edges.filter(
+                curriculum=curriculum
+            ).values_list("prerequisite_course_id", flat=True)
+            if all(req_id in passed_ids for req_id in req_ids):
+                allowed_ids.append(course.id)
+        return Course.objects.filter(id__in=allowed_ids)
 
     def save(self, *args, **kwargs):
         """Make sure we have a curriculum for all students."""

--- a/app/registry/admin/core.py
+++ b/app/registry/admin/core.py
@@ -4,6 +4,9 @@ from django.contrib import admin
 
 from app.registry.models.class_roster import ClassRoster
 from app.registry.models.grade import Grade
+from app.registry.models.registration import Registration
+from app.people.models.student import Student
+from app.timetable.models.section import Section
 
 
 @admin.register(Grade)
@@ -52,3 +55,38 @@ class ClassRosterAdmin(admin.ModelAdmin):
     def student_count(self, obj: ClassRoster) -> int:
         """Return number of students enrolled in this roster."""
         return obj.students.count()
+
+
+@admin.register(Registration)
+class RegistrationAdmin(admin.ModelAdmin):
+    """Allow students to register only for eligible sections."""
+
+    list_display = ("student", "section", "status", "date_registered")
+    autocomplete_fields = ("student", "section")
+    search_fields = (
+        "student__student_id",
+        "section__program__course__code",
+        "section__number",
+    )
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        try:
+            student = request.user.student
+        except Student.DoesNotExist:
+            return qs.none()
+        return qs.filter(student=student)
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "section" and not request.user.is_superuser:
+            try:
+                student = request.user.student
+            except Student.DoesNotExist:
+                kwargs["queryset"] = Section.objects.none()
+            else:
+                kwargs["queryset"] = Section.objects.filter(
+                    program__course__in=student.allowed_courses()
+                )
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/app/shared/types.py
+++ b/app/shared/types.py
@@ -7,7 +7,9 @@ if TYPE_CHECKING:
     from app.timetable.models import Section
     from app.academics.models import Course
     from app.people.models.profile import StudentProfile
+    from app.registry.models import Registration
 
 SectionQuery: TypeAlias = QuerySet["Section"]
 CourseQuery: TypeAlias = QuerySet["Course"]
 StudentProfileQuery: TypeAlias = QuerySet["StudentProfile"]
+RegistrationQuery: TypeAlias = QuerySet["Registration"]

--- a/tests/academics/test_student_courses.py
+++ b/tests/academics/test_student_courses.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.academics.models.course import Course
+from app.academics.models.program import Program
+from app.academics.models.prerequisite import Prerequisite
+from app.people.models.student import Student
+from app.registry.models.grade import Grade
+from app.timetable.models.section import Section
+
+
+@pytest.mark.django_db
+def test_allowed_courses(student: Student, semester):
+    course_a = Course.objects.create(number="101")
+    course_b = Course.objects.create(number="102")
+    Program.objects.create(curriculum=student.curriculum, course=course_a)
+    Program.objects.create(curriculum=student.curriculum, course=course_b)
+    Prerequisite.objects.create(
+        course=course_b, prerequisite_course=course_a, curriculum=student.curriculum
+    )
+    prog_a = Program.objects.get(course=course_a, curriculum=student.curriculum)
+    sec_a = Section.objects.create(program=prog_a, semester=semester, number=1)
+    Grade.objects.create(
+        student=student, section=sec_a, letter_grade="A", numeric_grade=90
+    )
+
+    allowed = list(student.allowed_courses())
+    assert course_b in allowed
+    assert course_a not in allowed


### PR DESCRIPTION
## Summary
- restrict sections in admin to faculty's own courses
- add registration admin limiting course selection to allowed courses
- track passed courses for students
- expose allowed course filtering based on prerequisites
- fix typos in docs and code comments
- type hint registration queryset
- add regression test for allowed course logic

## Testing
- `flake8 app tests/academics/test_student_courses.py`
- `black app/shared/types.py app/academics/models/curriculum.py app/academics/models/department.py app/academics/admin/widgets.py app/people/models/staffs.py app/people/models/student.py app/registry/admin/core.py app/timetable/admin/registers/section.py tests/academics/test_student_courses.py`
- `mypy app` *(fails: ModuleNotFoundError: No module named 'django_extensions')*
- `pytest -q tests/academics/test_student_courses.py --ds=app.settings` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_685dcb0100648323bee42710867431d1