### PR TITLE
Add CRUD tests for academics models

### DIFF
--- a/tests/academics/test_college_crud.py
+++ b/tests/academics/test_college_crud.py
@@ -1,0 +1,26 @@
+import pytest
+from app.academics.choices import CollegeLongNameChoices
+from app.academics.models.college import College
+
+
+@pytest.mark.django_db
+def test_college_crud(college_factory):
+    # create
+    college = college_factory(code="COHS")
+    assert College.objects.filter(pk=college.pk).exists()
+
+    # read
+    fetched = College.objects.get(pk=college.pk)
+    assert fetched == college
+
+    # update
+    fetched.code = "COED"
+    fetched.long_name = CollegeLongNameChoices.COED.label
+    fetched.save()
+    updated = College.objects.get(pk=college.pk)
+    assert updated.code == "COED"
+
+    # delete
+    updated.delete()
+    assert not College.objects.filter(pk=college.pk).exists()
+

--- a/tests/academics/test_concentration_crud.py
+++ b/tests/academics/test_concentration_crud.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.academics.models.concentration import Concentration
+
+
+@pytest.mark.django_db
+def test_concentration_crud(curriculum):
+    # create
+    concentration = Concentration.objects.create(
+        name="Statistics",
+        curriculum=curriculum,
+    )
+    assert Concentration.objects.filter(pk=concentration.pk).exists()
+
+    # read
+    fetched = Concentration.objects.get(pk=concentration.pk)
+    assert fetched == concentration
+
+    # update
+    fetched.name = "Math Stats"
+    fetched.save()
+    updated = Concentration.objects.get(pk=concentration.pk)
+    assert updated.name == "Math Stats"
+
+    # delete
+    updated.delete()
+    assert not Concentration.objects.filter(pk=concentration.pk).exists()
+

--- a/tests/academics/test_course_crud.py
+++ b/tests/academics/test_course_crud.py
@@ -1,0 +1,26 @@
+import pytest
+
+from app.academics.models.course import Course
+
+
+@pytest.mark.django_db
+def test_course_crud(course_factory, department_factory):
+    # create
+    dept = department_factory()
+    course = Course.objects.create(number="901", title="Intro", department=dept)
+    assert Course.objects.filter(pk=course.pk).exists()
+
+    # read
+    fetched = Course.objects.get(pk=course.pk)
+    assert fetched == course
+
+    # update
+    fetched.title = "Introduction"
+    fetched.save()
+    updated = Course.objects.get(pk=course.pk)
+    assert updated.title == "Introduction"
+
+    # delete
+    updated.delete()
+    assert not Course.objects.filter(pk=course.pk).exists()
+

--- a/tests/academics/test_curriculum_crud.py
+++ b/tests/academics/test_curriculum_crud.py
@@ -1,0 +1,37 @@
+import pytest
+from app.shared.status.mixins import StatusHistory
+from django.db import connection
+
+from app.academics.models.curriculum import Curriculum
+
+
+@pytest.mark.django_db
+def test_curriculum_crud(college_factory):
+    # create
+    college = college_factory()
+    curriculum = Curriculum.objects.create(
+        short_name="BSCM",
+        long_name="Computer Management",
+        college=college,
+    )
+    assert Curriculum.objects.filter(pk=curriculum.pk).exists()
+
+    # read
+    fetched = Curriculum.objects.get(pk=curriculum.pk)
+    assert fetched == curriculum
+
+    # update
+    fetched.long_name = "Computer Management Updated"
+    fetched.save()
+    updated = Curriculum.objects.get(pk=curriculum.pk)
+    assert updated.long_name == "Computer Management Updated"
+
+    # delete
+    tables = connection.introspection.table_names()
+    if StatusHistory._meta.db_table not in tables:
+        from django.db import connection as conn
+        with conn.schema_editor() as schema:
+            schema.create_model(StatusHistory)
+    updated.delete()
+    assert not Curriculum.objects.filter(pk=curriculum.pk).exists()
+

--- a/tests/academics/test_department_crud.py
+++ b/tests/academics/test_department_crud.py
@@ -1,0 +1,29 @@
+import pytest
+
+from app.academics.models.department import Department
+
+
+@pytest.mark.django_db
+def test_department_crud(department_factory, college_factory):
+    # create
+    dept = Department.objects.create(
+        short_name="MATH",
+        full_name="Mathematics",
+        college=college_factory(code="COAS"),
+    )
+    assert Department.objects.filter(pk=dept.pk).exists()
+
+    # read
+    fetched = Department.objects.get(pk=dept.pk)
+    assert fetched == dept
+
+    # update
+    fetched.full_name = "Applied Mathematics"
+    fetched.save()
+    updated = Department.objects.get(pk=dept.pk)
+    assert updated.full_name == "Applied Mathematics"
+
+    # delete
+    updated.delete()
+    assert not Department.objects.filter(pk=dept.pk).exists()
+

--- a/tests/academics/test_prerequisite_crud.py
+++ b/tests/academics/test_prerequisite_crud.py
@@ -1,0 +1,31 @@
+import pytest
+
+from app.academics.models.prerequisite import Prerequisite
+
+
+@pytest.mark.django_db
+def test_prerequisite_crud(curriculum, course_factory):
+    # create
+    course_a = course_factory("201", "A")
+    course_b = course_factory("202", "B")
+    prereq = Prerequisite.objects.create(
+        curriculum=curriculum,
+        course=course_b,
+        prerequisite_course=course_a,
+    )
+    assert Prerequisite.objects.filter(pk=prereq.pk).exists()
+
+    # read
+    fetched = Prerequisite.objects.get(pk=prereq.pk)
+    assert fetched == prereq
+
+    # update
+    fetched.prerequisite_course = course_factory("203", "C")
+    fetched.save()
+    updated = Prerequisite.objects.get(pk=prereq.pk)
+    assert updated.prerequisite_course.number == "203"
+
+    # delete
+    updated.delete()
+    assert not Prerequisite.objects.filter(pk=prereq.pk).exists()
+

--- a/tests/academics/test_program_crud.py
+++ b/tests/academics/test_program_crud.py
@@ -1,0 +1,28 @@
+import pytest
+from app.academics.models.curriculum import Curriculum
+from app.academics.models.program import Program
+
+
+@pytest.mark.django_db
+def test_program_crud(course_factory, college_factory):
+    # create related objects
+    college = college_factory()
+    curriculum = Curriculum.objects.create(short_name="TPRG", college=college)
+    course = course_factory("201", "Advanced")
+    program = Program.objects.create(curriculum=curriculum, course=course)
+    assert Program.objects.filter(pk=program.pk).exists()
+
+    # read
+    fetched = Program.objects.get(pk=program.pk)
+    assert fetched == program
+
+    # update
+    fetched.is_required = False
+    fetched.save()
+    updated = Program.objects.get(pk=program.pk)
+    assert updated.is_required is False
+
+    # delete
+    updated.delete()
+    assert not Program.objects.filter(pk=program.pk).exists()
+


### PR DESCRIPTION
## Summary
- add CRUD tests for college, department, course, curriculum, program, prerequisite and concentration models

## Testing
- `codo-tuth-env/bin/python -m pytest -q` *(fails: SQLite schema editor cannot be used while foreign key constraint checks are enabled; UNIQUE constraint failed; Field 'id' expected a number but got <Space: TBA>)*

------
https://chatgpt.com/codex/tasks/task_e_685edbc216688323bd3bd920f801f4f2