### PR TITLE
Add tests for unique constraints

### DIFF
--- a/tests/academics/test_unique_constraints.py
+++ b/tests/academics/test_unique_constraints.py
@@ -1,0 +1,68 @@
+"""Tests for DB unique constraints in academics models."""
+
+import pytest
+from django.db import IntegrityError
+
+from app.academics.models.curriculum import Curriculum
+from app.academics.models.college import College
+from app.academics.models.department import Department
+from app.academics.models.course import Course
+from app.academics.models.program import Program
+from app.academics.models.prerequisite import Prerequisite
+
+pytestmark = pytest.mark.django_db
+
+
+def test_department_unique_short_name(college):
+    Department.objects.create(code="D1", short_name="GEN", college=college)
+    with pytest.raises(IntegrityError):
+        Department.objects.create(code="D2", short_name="GEN", college=college)
+
+
+def test_course_number_per_department(department):
+    Course.objects.create(department=department, number="101")
+    with pytest.raises(IntegrityError):
+        Course.objects.create(department=department, number="101")
+
+
+def test_program_unique_course_per_curriculum(course):
+    curriculum = Curriculum.objects.create(
+        short_name="UNIQCUR",
+        long_name="Unique Curriculum",
+        college=College.get_default(),
+    )
+    Program.objects.create(curriculum=curriculum, course=course)
+    with pytest.raises(IntegrityError):
+        Program.objects.create(curriculum=curriculum, course=course)
+
+
+def test_prerequisite_unique_per_curriculum(course_factory):
+    curriculum = Curriculum.objects.create(
+        short_name="CURPRQ",
+        long_name="Curriculum for prereqs",
+        college=College.get_default(),
+    )
+    c1 = course_factory("201", "First")
+    c2 = course_factory("202", "Second")
+    Prerequisite.objects.create(
+        curriculum=curriculum, course=c2, prerequisite_course=c1
+    )
+    with pytest.raises(IntegrityError):
+        Prerequisite.objects.create(
+            curriculum=curriculum, course=c2, prerequisite_course=c1
+        )
+
+
+def test_prerequisite_no_self(course):
+    curriculum = Curriculum.objects.create(
+        short_name="CURSELF",
+        long_name="Curriculum self prereq",
+        college=College.get_default(),
+    )
+    with pytest.raises(IntegrityError):
+        Prerequisite.objects.create(
+            curriculum=curriculum,
+            course=course,
+            prerequisite_course=course,
+        )
+

--- a/tests/people/test_role_assignment.py
+++ b/tests/people/test_role_assignment.py
@@ -1,0 +1,19 @@
+"""Tests for unique constraints on RoleAssignment model."""
+
+from datetime import date
+
+import pytest
+from django.db import IntegrityError
+
+from app.people.models.role_assignment import RoleAssignment
+from app.people.choices import UserRole
+
+pytestmark = pytest.mark.django_db
+
+
+def test_unique_role_per_period(user, college):
+    start = date.today()
+    RoleAssignment.objects.create(user=user, role=UserRole.REGISTRAR, college=college, start_date=start)
+    with pytest.raises(IntegrityError):
+        RoleAssignment.objects.create(user=user, role=UserRole.REGISTRAR, college=college, start_date=start)
+

--- a/tests/registry/test_unique_constraints.py
+++ b/tests/registry/test_unique_constraints.py
@@ -1,0 +1,69 @@
+"""Tests for unique constraints in registry models."""
+
+import pytest
+from django.db import IntegrityError
+
+from app.registry.models.registration import Registration
+from app.registry.models.grade import Grade
+from app.academics.models.program import Program
+from app.academics.models.course import Course
+from app.academics.models.curriculum import Curriculum
+from app.academics.models.college import College
+from app.timetable.models.section import Section
+from app.timetable.models.semester import Semester
+
+pytestmark = pytest.mark.django_db
+
+
+def test_registration_unique_student_section(student, semester):
+    curriculum = Curriculum.objects.create(
+        short_name="CURREG",
+        long_name="Registration Curriculum",
+        college=College.get_default(),
+    )
+    course = Course.get_unique_default()
+    program = Program.objects.create(curriculum=curriculum, course=course)
+    sec = Section.objects.create(
+        program=program,
+        semester=semester,
+        number=1,
+        start_date=semester.start_date,
+        end_date=semester.end_date,
+        max_seats=30,
+    )
+    Registration.objects.create(student=student, section=sec)
+    with pytest.raises(IntegrityError):
+        Registration.objects.create(student=student, section=sec)
+
+
+def test_grade_unique_student_section(student, semester):
+    curriculum = Curriculum.objects.create(
+        short_name="CURGRD",
+        long_name="Grade Curriculum",
+        college=College.get_default(),
+    )
+    course = Course.get_unique_default()
+    program = Program.objects.create(curriculum=curriculum, course=course)
+    sec = Section.objects.create(
+        program=program,
+        semester=semester,
+        number=1,
+        start_date=semester.start_date,
+        end_date=semester.end_date,
+        max_seats=30,
+    )
+    Grade.objects.create(
+        student=student,
+        section=sec,
+        letter_grade="A",
+        numeric_grade=90,
+    )
+    with pytest.raises(IntegrityError):
+        Grade.objects.create(
+            student=student,
+            section=sec,
+            letter_grade="B",
+            numeric_grade=80,
+        )
+
+

--- a/tests/timetable/test_unique_constraints.py
+++ b/tests/timetable/test_unique_constraints.py
@@ -1,0 +1,64 @@
+"""Tests for unique constraints in timetable models."""
+
+import pytest
+from django.db import IntegrityError
+
+from app.timetable.models.semester import Semester
+from app.timetable.models.term import Term
+from app.timetable.models.section import Section
+from app.academics.models.program import Program
+from app.academics.models.course import Course
+from app.academics.models.curriculum import Curriculum
+from app.academics.models.college import College
+
+pytestmark = pytest.mark.django_db
+
+
+def test_semester_unique_number_per_year(academic_year):
+    Semester.objects.create(
+        academic_year=academic_year,
+        number=1,
+        start_date=academic_year.start_date,
+        end_date=academic_year.end_date,
+    )
+    with pytest.raises(IntegrityError):
+        Semester.objects.create(
+            academic_year=academic_year,
+            number=1,
+            start_date=academic_year.start_date,
+            end_date=academic_year.end_date,
+        )
+
+
+def test_term_unique_number_per_semester(semester):
+    Term.objects.create(semester=semester, number=1)
+    with pytest.raises(IntegrityError):
+        Term.objects.create(semester=semester, number=1)
+
+
+def test_section_unique_per_program(semester, course):
+    curriculum = Curriculum.objects.create(
+        short_name="CURSEC",
+        long_name="Section Curriculum",
+        college=College.get_default(),
+    )
+    program = Program.objects.create(curriculum=curriculum, course=course)
+    Section.objects.create(
+        program=program,
+        semester=semester,
+        number=1,
+        start_date=semester.start_date,
+        end_date=semester.end_date,
+        max_seats=30,
+    )
+    with pytest.raises(IntegrityError):
+        Section.objects.create(
+            program=program,
+            semester=semester,
+            number=1,
+            start_date=semester.start_date,
+            end_date=semester.end_date,
+            max_seats=30,
+        )
+
+


### PR DESCRIPTION
## Summary
- test department/course/program/prerequisite constraints
- test registration and grade duplicates blocked
- test semester/term/section constraints
- test role assignment uniqueness

## Testing
- `pytest -q` *(fails: Field 'id' expected a number but got <Space: TBA>)*

------
https://chatgpt.com/codex/tasks/task_e_685edbd03da083239e1d47bd7fe6493f