### PR TITLE
Fix Space.get_default to return saved instance

### DIFF
--- a/app/spaces/models/core.py
+++ b/app/spaces/models/core.py
@@ -31,7 +31,7 @@ class Space(models.Model):
         tba_space, _ = cls.objects.get_or_create(
             code="TBA", defaults={"full_name": "Undefined space (TBA)"}
         )
-        return cls(tba_space)
+        return tba_space
 
     class Meta:
         verbose_name = "Space / Buiding"

--- a/tests/spaces/test_space_default.py
+++ b/tests/spaces/test_space_default.py
@@ -1,0 +1,17 @@
+"""Tests for Space.get_default()."""
+
+import pytest
+
+from app.spaces.models.core import Space
+
+pytestmark = pytest.mark.django_db
+
+
+def test_space_get_default_returns_saved_instance():
+    """Calling get_default should return a persisted Space object."""
+    space = Space.get_default()
+    assert space.pk is not None
+    # ensure that retrieving again returns the same record
+    same_space = Space.get_default()
+    assert same_space.pk == space.pk
+


### PR DESCRIPTION
## Summary
- fix `Space.get_default` to return the fetched instance
- test default space returns a saved record

## Testing
- `pip install -r requirements-test.txt`
- `.venv/bin/python -m pytest -q` *(fails: UNIQUE constraint failed in some finance and student tests)*

------
https://chatgpt.com/codex/tasks/task_e_685edbf43b508323a27bbf14f7e9a910