### PR TITLE
Add missing fixtures across test modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,4 +10,7 @@ pytest_plugins = [
     "tests.academics.fixture",
     "tests.people.fixture",
     "tests.spaces.fixture",
+    "tests.finance.fixture",
+    "tests.registry.fixture",
+    "tests.shared.fixture",
 ]

--- a/tests/finance/fixture.py
+++ b/tests/finance/fixture.py
@@ -1,1 +1,141 @@
-"""Tests Fixtures of the finance module."""
+"""Test fixtures of the finance app.
+
+Factories return callables for creating additional objects on demand.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Callable, TypeAlias
+
+import pytest
+
+from app.finance.choices import PaymentMethod
+from app.finance.models import (
+    FinancialRecord,
+    Payment,
+    PaymentHistory,
+    Scholarship,
+)
+from app.people.models.donor import Donor
+from app.people.models.staffs import Staff
+from app.people.models.student import Student
+from app.academics.models.program import Program
+
+FinancialRecordFactory: TypeAlias = Callable[[Student, Decimal], FinancialRecord]
+PaymentFactory: TypeAlias = Callable[[Program, Staff, Decimal], Payment]
+PaymentHistoryFactory: TypeAlias = Callable[[FinancialRecord, Staff, Decimal], PaymentHistory]
+ScholarshipFactory: TypeAlias = Callable[[Donor, Student, Decimal], Scholarship]
+
+
+@pytest.fixture
+def financial_record(student: Student) -> FinancialRecord:
+    """Default financial record for a student."""
+
+    return FinancialRecord.objects.create(student=student, total_due=Decimal("0"))
+
+
+@pytest.fixture
+def payment(financial_record: FinancialRecord, staff: Staff, program: Program) -> Payment:
+    """Default payment record for a program."""
+
+    return Payment.objects.create(
+        program=program,
+        amount=Decimal("1"),
+        method=PaymentMethod.CASH,
+        recorded_by=staff,
+    )
+
+
+@pytest.fixture
+def payment_history(financial_record: FinancialRecord, staff: Staff) -> PaymentHistory:
+    """Default payment history entry."""
+
+    return PaymentHistory.objects.create(
+        financial_record=financial_record,
+        amount=Decimal("1"),
+        recorded_by=staff,
+    )
+
+
+@pytest.fixture
+def scholarship(donor: Donor, student: Student) -> Scholarship:
+    """Default scholarship linking donor and student."""
+
+    return Scholarship.objects.create(
+        donor=donor,
+        student=student,
+        amount=Decimal("1"),
+        start_date=date.today(),
+    )
+
+
+# ─── factory fixtures ──────────────────────────────────────────────────────
+
+@pytest.fixture
+def financial_record_factory() -> FinancialRecordFactory:
+    """Return a callable to build financial records."""
+
+    def _make(student: Student, total_due: Decimal = Decimal("0")) -> FinancialRecord:
+        return FinancialRecord.objects.create(student=student, total_due=total_due)
+
+    return _make
+
+
+@pytest.fixture
+def payment_factory() -> PaymentFactory:
+    """Return a callable to build payment records."""
+
+    def _make(
+        program: Program,
+        staff: Staff,
+        amount: Decimal = Decimal("1"),
+    ) -> Payment:
+        return Payment.objects.create(
+            program=program,
+            amount=amount,
+            method=PaymentMethod.CASH,
+            recorded_by=staff,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def payment_history_factory() -> PaymentHistoryFactory:
+    """Return a callable to build payment history entries."""
+
+    def _make(
+        financial_record: FinancialRecord,
+        staff: Staff,
+        amount: Decimal = Decimal("1"),
+    ) -> PaymentHistory:
+        return PaymentHistory.objects.create(
+            financial_record=financial_record,
+            amount=amount,
+            recorded_by=staff,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def scholarship_factory() -> ScholarshipFactory:
+    """Return a callable to build scholarships."""
+
+    def _make(
+        donor: Donor,
+        student: Student,
+        amount: Decimal = Decimal("1"),
+        start_date: date = date.today(),
+    ) -> Scholarship:
+        return Scholarship.objects.create(
+            donor=donor,
+            student=student,
+            amount=amount,
+            start_date=start_date,
+        )
+
+    return _make
+

--- a/tests/registry/fixture.py
+++ b/tests/registry/fixture.py
@@ -1,1 +1,128 @@
-"""Tests fixtures for the registry module."""
+"""Test fixtures for the registry app."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Callable, TypeAlias
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from app.registry.choices import DocumentType, StatusRegistration
+from app.registry.models import ClassRoster, Document, Grade, Registration
+from app.people.models.student import Student
+from app.timetable.models.section import Section
+
+DocumentFactory: TypeAlias = Callable[[Student], Document]
+RegistrationFactory: TypeAlias = Callable[[Student, Section], Registration]
+GradeFactory: TypeAlias = Callable[[Student, Section, str], Grade]
+ClassRosterFactory: TypeAlias = Callable[[Section], ClassRoster]
+
+
+@pytest.fixture
+def registration(student: Student, section: Section) -> Registration:
+    """Default registration for a student."""
+
+    return Registration.objects.create(student=student, section=section)
+
+
+@pytest.fixture
+def grade(student: Student, section: Section) -> Grade:
+    """Default grade for a student in a section."""
+
+    return Grade.objects.create(
+        student=student,
+        section=section,
+        letter_grade="A",
+        numeric_grade=Decimal("90"),
+    )
+
+
+@pytest.fixture
+def document(student: Student) -> Document:
+    """Default document attached to a student."""
+
+    ct = ContentType.objects.get_for_model(student)
+    file_data = SimpleUploadedFile("doc.txt", b"data")
+    return Document.objects.create(
+        profile_type=ct,
+        profile_id=student.id,
+        data_file=file_data,
+        document_type=DocumentType.WAEC,
+    )
+
+
+@pytest.fixture
+def class_roster(section: Section) -> ClassRoster:
+    """Default class roster for a section."""
+
+    return ClassRoster.objects.create(section=section)
+
+
+# ─── factory fixtures ──────────────────────────────────────────────────────
+
+@pytest.fixture
+def registration_factory() -> RegistrationFactory:
+    """Return a callable to build registrations."""
+
+    def _make(
+        student: Student,
+        section: Section,
+        status: str = StatusRegistration.PENDING,
+    ) -> Registration:
+        return Registration.objects.create(
+            student=student,
+            section=section,
+            status=status,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def grade_factory() -> GradeFactory:
+    """Return a callable to build grades."""
+
+    def _make(
+        student: Student,
+        section: Section,
+        letter: str = "A",
+        numeric: Decimal = Decimal("90"),
+    ) -> Grade:
+        return Grade.objects.create(
+            student=student,
+            section=section,
+            letter_grade=letter,
+            numeric_grade=numeric,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def document_factory() -> DocumentFactory:
+    """Return a callable to build documents."""
+
+    def _make(student: Student) -> Document:
+        ct = ContentType.objects.get_for_model(student)
+        file_data = SimpleUploadedFile("doc.txt", b"data")
+        return Document.objects.create(
+            profile_type=ct,
+            profile_id=student.id,
+            data_file=file_data,
+            document_type=DocumentType.WAEC,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def class_roster_factory() -> ClassRosterFactory:
+    """Return a callable to build class rosters."""
+
+    def _make(section: Section) -> ClassRoster:
+        return ClassRoster.objects.create(section=section)
+
+    return _make
+

--- a/tests/shared/fixture.py
+++ b/tests/shared/fixture.py
@@ -1,1 +1,65 @@
-"""Tests fixtures of the shared module."""
+"""Test fixtures of the shared module."""
+
+from __future__ import annotations
+
+from typing import Callable, TypeAlias
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+from django.db.utils import OperationalError
+
+from app.people.models.student import Student
+from app.shared.status.mixins import StatusHistory
+
+StatusHistoryFactory: TypeAlias = Callable[[Student, str], StatusHistory]
+
+
+def _ensure_table() -> None:
+    """Create the status history table if absent."""
+
+    table = StatusHistory._meta.db_table
+    with connection.cursor() as cursor:
+        try:
+            cursor.execute(f"SELECT 1 FROM {table} LIMIT 1")
+        except OperationalError:
+            with connection.schema_editor() as schema_editor:
+                schema_editor.create_model(StatusHistory)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _status_history_table(django_db_setup, django_db_blocker) -> None:
+    """Ensure the StatusHistory table exists for all tests."""
+
+    with django_db_blocker.unblock():
+        _ensure_table()
+
+
+@pytest.fixture
+def status_history(student: Student) -> StatusHistory:
+    """Default status history attached to a student."""
+
+    _ensure_table()
+    ct = ContentType.objects.get_for_model(student)
+    return StatusHistory.objects.create(
+        status="pending",
+        content_type=ct,
+        object_id=student.id,
+    )
+
+
+@pytest.fixture
+def status_history_factory() -> StatusHistoryFactory:
+    """Return a callable to build status history entries."""
+
+    def _make(student: Student, status: str = "pending") -> StatusHistory:
+        _ensure_table()
+        ct = ContentType.objects.get_for_model(student)
+        return StatusHistory.objects.create(
+            status=status,
+            content_type=ct,
+            object_id=student.id,
+        )
+
+    return _make
+

--- a/tests/timetable/test_session.py
+++ b/tests/timetable/test_session.py
@@ -11,16 +11,16 @@ pytestmark = pytest.mark.django_db  # replace the @pytest.mark.django_db decorat
 
 # ~~~~~~~~~~~~~~~~ DB Constraints ~~~~~~~~~~~~~~~~
 
-def test_uniq_schedule_per_section(room, section):
+def test_uniq_schedule_per_section(room, section, schedule):
     """In session, a (section, schedule) pair may appear at most once in Session rows.
 
     1. First insert ⟶ OK
     2. Second insert with the *same* pair ⟶ IntegrityError (DB-level)
     """
     # first row — should succeed
-    Session.objects.create(room=room, section=section)
+    Session.objects.create(room=room, section=section, schedule=schedule)
 
     with pytest.raises(IntegrityError):
         # use a sub-transaction so the IntegrityError does not abort the test DB
         with transaction.atomic():
-            Session.objects.create(room=room, section=section)
+            Session.objects.create(room=room, section=section, schedule=schedule)


### PR DESCRIPTION
## Summary
- ensure all apps provide test fixtures and factories
- include new fixtures in pytest plugins
- fix session constraint test by providing schedule parameter
- auto-create StatusHistory table for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617a29cb4c83238b5441bfff4fef20