### PR TITLE
Organize model fields

### DIFF
--- a/app/academics/models/college.py
+++ b/app/academics/models/college.py
@@ -19,12 +19,15 @@ class College(models.Model):
 
     # ! there should be no constraint here as the VPA may need to
     # rework the name of the colleges from time to time.
+
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     code = models.CharField(
         max_length=4,
         choices=CollegeCodeChoices.choices,
         default=CollegeCodeChoices.COAS,
     )
 
+    # ~~~~ Auto-filled ~~~~
     long_name = models.CharField(
         max_length=50,
         choices=CollegeLongNameChoices.choices,

--- a/app/academics/models/concentration.py
+++ b/app/academics/models/concentration.py
@@ -15,7 +15,7 @@ class Concentration(models.Model):
         >>> Concentration.objects.create(name="Statistics", curriculum=curriculum)
     """
 
-    # revoir
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     name = models.CharField(max_length=255)
     curriculum = models.ForeignKey(
         "academics.curriculum",

--- a/app/academics/models/course.py
+++ b/app/academics/models/course.py
@@ -27,18 +27,20 @@ class Course(models.Model):
         save() populates code from name and number.
     """
 
-    # mandatory
+    # ~~~~~~~~ Mandatory ~~~~~~~~
+    number = models.CharField(max_length=10)  # e.g. 101
+
+    # ~~~~ Auto-filled ~~~~
     department = models.ForeignKey(
         "academics.Department",
         on_delete=models.CASCADE,
         related_name="courses",
     )
-    number = models.CharField(max_length=10)  # e.g. 101
 
-    # non editable
+    # ~~~~ Read-only ~~~~
     code = models.CharField(max_length=20, editable=False)
 
-    # optional
+    # ~~~~~~~~ Optional ~~~~~~~~
     title = models.CharField(max_length=255, blank=True, null=True)
     description: models.TextField = models.TextField(blank=True, null=True)
     prerequisites = models.ManyToManyField(

--- a/app/academics/models/curriculum.py
+++ b/app/academics/models/curriculum.py
@@ -22,27 +22,28 @@ class Curriculum(StatusableMixin, models.Model):
     otherwise the student is limited to the courses listed in their curriculum.
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     short_name = models.CharField(max_length=40)
-    long_name = models.CharField(max_length=255, blank=True, null=True)
 
+    # ~~~~ Auto-filled ~~~~
     college = models.ForeignKey(
         "academics.College", on_delete=models.CASCADE, related_name="curricula"
     )
+    creation_date = models.DateField(default=date.today)
+    is_active = models.BooleanField(default=False)
+    status = models.CharField(
+        max_length=30,
+        choices=StatusCurriculum.choices,
+        default=StatusCurriculum.PENDING,
+    )
+
+    # ~~~~~~~~ Optional ~~~~~~~~
+    long_name = models.CharField(max_length=255, blank=True, null=True)
     courses = models.ManyToManyField(
         "academics.Course",
         through="academics.Program",
         related_name="curricula",  # <-- reverse accessor course.curricula
         blank=True,
-    )
-    # a constraint is that we should not have a curriculum in a college
-    # created in the same year with same title
-    creation_date = models.DateField(default=date.today)
-    is_active = models.BooleanField(default=False)
-
-    status = models.CharField(
-        max_length=30,
-        choices=StatusCurriculum.choices,
-        default=StatusCurriculum.PENDING,
     )
 
     def __str__(self) -> str:  # pragma: no cover

--- a/app/academics/models/department.py
+++ b/app/academics/models/department.py
@@ -13,7 +13,7 @@ class Department(models.Model):
     Example: see get_default()
     """
 
-    # mandatory
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     short_name = models.CharField(max_length=6)
     # woulde be good to restric this to a few dept.
     # but it is also here that I should set the Truth
@@ -23,7 +23,7 @@ class Department(models.Model):
     #     default=DepartmentShortNameChoice.DEFT,
     # )
 
-    # Auto-completed
+    # ~~~~ Auto-filled ~~~~
     college = models.ForeignKey(
         "academics.College",
         on_delete=models.PROTECT,
@@ -31,7 +31,7 @@ class Department(models.Model):
     )
     long_name = models.CharField(max_length=128, blank=True)
 
-    # non editable
+    # ~~~~ Read-only ~~~~
     code = models.CharField(max_length=50, unique=True, editable=False)
 
     def __str__(self) -> str:  # pragma: no cover

--- a/app/academics/models/prerequisite.py
+++ b/app/academics/models/prerequisite.py
@@ -16,12 +16,15 @@ class Prerequisite(models.Model):
         clean() prevents circular dependencies.
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     course = models.ForeignKey(
         "academics.Course", related_name="course_prereq_edges", on_delete=models.CASCADE
     )
     prerequisite_course = models.ForeignKey(
         "academics.Course", related_name="required_for_edges", on_delete=models.CASCADE
     )
+
+    # ~~~~~~~~ Optional ~~~~~~~~
     curriculum = models.ForeignKey(
         "academics.Curriculum",
         on_delete=models.CASCADE,

--- a/app/academics/models/program.py
+++ b/app/academics/models/program.py
@@ -30,7 +30,7 @@ class Program(models.Model):
         "academics.Course", on_delete=models.CASCADE, related_name="in_programs"
     )
 
-    # ~~ Autofilled if empty ~~
+    # ~~~~ Auto-filled ~~~~
     is_required = models.BooleanField(default=True)
 
     # credit hours depend on the curricula not the Course

--- a/app/finance/models/financial_record.py
+++ b/app/finance/models/financial_record.py
@@ -31,8 +31,11 @@ class FinancialRecord(models.Model):
         >>> FinancialRecord.objects.create(student=student_profile, total_due=0)
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     student = models.OneToOneField("people.Student", on_delete=models.CASCADE)
     total_due = models.DecimalField(max_digits=10, decimal_places=2)
+
+    # ~~~~ Auto-filled ~~~~
     total_paid = models.DecimalField(max_digits=10, decimal_places=2, default=0)
     clearance_status = models.CharField(
         max_length=50,
@@ -40,6 +43,8 @@ class FinancialRecord(models.Model):
         default=StatusClearance.PENDING,
     )
     last_updated = models.DateTimeField(auto_now=True)
+
+    # ~~~~~~~~ Optional ~~~~~~~~
     verified_by = models.ForeignKey(
         "people.Staff",
         null=True,
@@ -66,6 +71,7 @@ class SectionFee(models.Model):
         >>> SectionFee.objects.create(section=section, fee_type=FeeType.LAB, amount=50)
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)
     fee_type = models.CharField(max_length=50, choices=FeeType.choices)
     amount = models.DecimalField(max_digits=10, decimal_places=2)

--- a/app/finance/models/payment.py
+++ b/app/finance/models/payment.py
@@ -31,10 +31,15 @@ class Payment(models.Model):
         ... )
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     program = models.OneToOneField("academics.Program", on_delete=models.CASCADE)
     amount = models.DecimalField(max_digits=8, decimal_places=2)
     method = models.CharField(max_length=20, choices=PaymentMethod.choices)
+
+    # ~~~~~~~~ Optional ~~~~~~~~
     recorded_by = models.ForeignKey("people.Staff", null=True, on_delete=models.SET_NULL)
+
+    # ~~~~ Auto-filled ~~~~
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self) -> str:  # pragma: no cover

--- a/app/finance/models/payment_history.py
+++ b/app/finance/models/payment_history.py
@@ -27,11 +27,16 @@ class PaymentHistory(models.Model):
         ... )
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     financial_record = models.ForeignKey(
         "finance.FinancialRecord", related_name="payments", on_delete=models.CASCADE
     )
     amount = models.DecimalField(max_digits=10, decimal_places=2)
+
+    # ~~~~ Auto-filled ~~~~
     payment_date = models.DateTimeField(auto_now_add=True)
+
+    # ~~~~~~~~ Optional ~~~~~~~~
     method = models.CharField(max_length=50, blank=True)  # cash, bank, mobile …
     recorded_by = models.ForeignKey(
         "people.Staff",

--- a/app/finance/models/scholarship.py
+++ b/app/finance/models/scholarship.py
@@ -31,6 +31,7 @@ class Scholarship(models.Model):
         ... )
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     donor = models.ForeignKey(
         "people.Donor",
         on_delete=models.CASCADE,
@@ -43,6 +44,8 @@ class Scholarship(models.Model):
     )
     amount = models.DecimalField(max_digits=10, decimal_places=2)
     start_date = models.DateField()
+
+    # ~~~~~~~~ Optional ~~~~~~~~
     end_date = models.DateField(null=True, blank=True)
     conditions = models.TextField(blank=True)
 

--- a/app/people/models/donor.py
+++ b/app/people/models/donor.py
@@ -23,6 +23,7 @@ class Donor(AbstractPerson):
     ID_FIELD = "donor_id"
     ID_PREFIX = "TU_DNR"
 
+    # ~~~~ Read-only ~~~~
     donor_id = models.CharField(max_length=13, unique=True, editable=False, blank=False)
 
     class Meta:

--- a/app/people/models/role_assignment.py
+++ b/app/people/models/role_assignment.py
@@ -21,10 +21,14 @@ class RoleAssignment(models.Model):
         ... )
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     user = models.ForeignKey(
         "auth.User", on_delete=models.CASCADE, related_name="role_assignments"
     )
     role = models.CharField(max_length=30, choices=UserRole.choices)
+    start_date = models.DateField()
+
+    # ~~~~~~~~ Optional ~~~~~~~~
     college = models.ForeignKey(
         "academics.College",
         null=True,
@@ -32,7 +36,6 @@ class RoleAssignment(models.Model):
         on_delete=models.SET_NULL,
         related_name="role_assignments",
     )
-    start_date = models.DateField()
     end_date = models.DateField(null=True, blank=True)
 
     def __str__(self) -> str:

--- a/app/people/models/staffs.py
+++ b/app/people/models/staffs.py
@@ -37,7 +37,10 @@ class Staff(AbstractPerson):
     ID_FIELD = "staff_id"
     ID_PREFIX = "TU_STF"
 
+    # ~~~~ Auto-filled ~~~~
     staff_id = models.CharField(max_length=13, unique=True)
+
+    # ~~~~~~~~ Optional ~~~~~~~~
     employment_date = models.DateField(null=True, blank=True)
 
     # > need to model an organogram where I can add division & departments

--- a/app/people/models/student.py
+++ b/app/people/models/student.py
@@ -28,8 +28,11 @@ class Student(AbstractPerson):
     ID_FIELD = "student_id"
     ID_PREFIX = "TU_STD"
 
+    # ~~~~ Auto-filled ~~~~
     student_id = models.CharField(max_length=20, unique=True)
     curriculum = models.ForeignKey("academics.Curriculum", on_delete=models.CASCADE)
+
+    # ~~~~~~~~ Optional ~~~~~~~~
     current_enroled_semester = models.ForeignKey(
         Semester,
         on_delete=models.PROTECT,

--- a/app/registry/models/class_roster.py
+++ b/app/registry/models/class_roster.py
@@ -19,7 +19,10 @@ class ClassRoster(models.Model):
         0
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     section = models.OneToOneField("timetable.Section", on_delete=models.CASCADE)
+
+    # ~~~~ Auto-filled ~~~~
     last_updated = models.DateTimeField(auto_now=True)
 
     @property

--- a/app/registry/models/document.py
+++ b/app/registry/models/document.py
@@ -32,11 +32,15 @@ class Document(StatusableMixin, models.Model):
     """
 
     # ! the folowing 2 are not too clear. needs clarifications
+
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     profile_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     profile_id = models.PositiveIntegerField()
     profile = GenericForeignKey("profile_type", "profile_id")
     data_file = models.FileField(upload_to="documents/")
     document_type = models.CharField(max_length=50, choices=DocumentType.choices)
+
+    # ~~~~ Auto-filled ~~~~
     status = models.CharField(
         max_length=30,
         choices=StatusDocument.choices,

--- a/app/registry/models/grade.py
+++ b/app/registry/models/grade.py
@@ -16,10 +16,13 @@ class Grade(models.Model):
         ... )
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     student = models.ForeignKey("people.Student", on_delete=models.CASCADE)
     section = models.ForeignKey("timetable.Section", on_delete=models.CASCADE)
     letter_grade = models.CharField(max_length=2)  # A+, A, B, etc.
     numeric_grade = models.DecimalField(max_digits=4, decimal_places=1)  # e.g., 85.5
+
+    # ~~~~ Auto-filled ~~~~
     graded_on = models.DateField(auto_now_add=True)
 
     class Meta:

--- a/app/registry/models/registration.py
+++ b/app/registry/models/registration.py
@@ -19,6 +19,7 @@ class Registration(StatusableMixin, models.Model):
         ... )
     """
 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     student = models.ForeignKey(
         "people.Student",
         on_delete=models.CASCADE,
@@ -29,6 +30,8 @@ class Registration(StatusableMixin, models.Model):
         on_delete=models.CASCADE,
         related_name="section_registrations",
     )
+
+    # ~~~~ Auto-filled ~~~~
     # this is optional and I could get it through the SatusableMixin
     status = models.CharField(
         max_length=30,

--- a/app/spaces/models/core.py
+++ b/app/spaces/models/core.py
@@ -18,10 +18,11 @@ class Space(models.Model):
         >>> from app.spaces.models.core import Space
         >>> Space.objects.create(code="AA", full_name="Academic Annex")
     """
-    # ~~~~ Mandatory ~~~~
+
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     code = models.CharField(max_length=15, unique=True, db_index=True)
 
-    # ~~~~ Optional ~~~~
+    # ~~~~~~~~ Optional ~~~~~~~~
     # replace this to long name
     full_name = models.CharField(max_length=128, blank=True)
 
@@ -49,10 +50,11 @@ class Room(models.Model):
         >>> Room.objects.create(code="101", space=space)
     """
 
-    # ~~~~ Mandatory ~~~~ 
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     code = models.CharField(max_length=30)
-    space = models.ForeignKey(Space, on_delete=models.PROTECT, related_name="rooms")
 
+    # ~~~~ Auto-filled ~~~~
+    space = models.ForeignKey(Space, on_delete=models.PROTECT, related_name="rooms")
     standard_capacity = models.PositiveIntegerField(default=45)
     exam_capacity = models.PositiveIntegerField(default=30)
 

--- a/app/timetable/models/academic_year.py
+++ b/app/timetable/models/academic_year.py
@@ -19,10 +19,11 @@ class AcademicYear(models.Model):
         save() computes code and long_name.
     """
 
-    # ~~~~ Mandatory ~~~~
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     start_date = models.DateField(unique=True)
     end_date = models.DateField(unique=True)
-    # non editable
+
+    # ~~~~ Read-only ~~~~
     code = models.CharField(max_length=5, editable=False, unique=True)
     long_name = models.CharField(max_length=9, editable=False, unique=True)
 

--- a/app/timetable/models/schedule.py
+++ b/app/timetable/models/schedule.py
@@ -29,7 +29,7 @@ class Schedule(models.Model):
     REF_TIME = time(8, 0)
     REF_DATETIME = REF_DATE + timedelta(hours=REF_TIME.hour)
 
-    # ~~~~ Mandatory ~~~~
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     weekday = models.PositiveSmallIntegerField(
         choices=WEEKDAYS_NUMBER.choices,
         help_text="Week day number (Monday=1, Tuesday=2, …)",
@@ -37,7 +37,7 @@ class Schedule(models.Model):
     )
     start_time = models.TimeField()
 
-    # ~~~~ Optional ~~~~
+    # ~~~~~~~~ Optional ~~~~~~~~
     end_time = models.TimeField(null=True, blank=True)
 
     def __str__(self):

--- a/app/timetable/models/section.py
+++ b/app/timetable/models/section.py
@@ -31,14 +31,14 @@ class Section(models.Model):
         Section numbers auto-increment
     """
 
-    # ~~~~ Mandatory ~~~~
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     semester = models.ForeignKey("timetable.Semester", on_delete=models.PROTECT)
     program = models.ForeignKey(
         "academics.Program", on_delete=models.CASCADE, related_name="sections"
     )
     number = models.PositiveIntegerField(default=1, validators=[MinValueValidator(1)])
 
-    # ~~~~ Optional ~~~~
+    # ~~~~~~~~ Optional ~~~~~~~~
     faculty = models.ForeignKey(
         "people.Faculty",
         null=True,
@@ -49,7 +49,10 @@ class Section(models.Model):
     start_date = models.DateField(null=True, blank=True)
     end_date = models.DateField(null=True, blank=True)
 
+    # ~~~~ Read-only ~~~~
     current_registrations = models.PositiveIntegerField(default=0, editable=False)
+
+    # ~~~~ Auto-filled ~~~~
     # to be defined by Admin & VPA
     max_seats = models.PositiveIntegerField(default=30, validators=[MinValueValidator(3)])
 

--- a/app/timetable/models/semester.py
+++ b/app/timetable/models/semester.py
@@ -13,14 +13,14 @@ class Semester(models.Model):
         >>> Semester.objects.create(academic_year=year, number=1)
     """
 
-    # ~~~~ Mandatory ~~~~
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     academic_year = models.ForeignKey("timetable.AcademicYear", on_delete=models.PROTECT)
     number = models.PositiveSmallIntegerField(
         choices=SEMESTER_NUMBER.choices, help_text="Semester number"
     )
 
-    # ~~~~ Optional ~~~~
-    # > Could be interesting to set this to the academic_year start date automaticaly on save
+    # ~~~~~~~~ Optional ~~~~~~~~
+    # > Could be interesting to set this to the academic_year start date automatically on save
     # > and force non null values.
     start_date = models.DateField(null=True, blank=True)
     end_date = models.DateField(null=True, blank=True)

--- a/app/timetable/models/session.py
+++ b/app/timetable/models/session.py
@@ -19,7 +19,7 @@ class Session(models.Model):
         >>> Session.objects.create(room=room, schedule=schedule, section=section)
     """
 
-    # ~~~~ Mandatory ~~~~
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     room = models.ForeignKey("spaces.Room", on_delete=models.PROTECT)
     section = models.ForeignKey(
         "timetable.Section",
@@ -27,7 +27,7 @@ class Session(models.Model):
         related_name="sessions",
     )
 
-    # ~~~~ Optional ~~~~
+    # ~~~~~~~~ Optional ~~~~~~~~
     # ! be carreful with TBA schedules
     schedule = models.ForeignKey(
         "timetable.Schedule",

--- a/app/timetable/models/term.py
+++ b/app/timetable/models/term.py
@@ -14,7 +14,7 @@ class Term(models.Model):
         >>> Term.objects.create(semester=semester, number=1)
     """
 
-    # ### mandatory
+    # ~~~~~~~~ Mandatory ~~~~~~~~
     semester = models.ForeignKey(
         "timetable.Semester", on_delete=models.PROTECT, related_name="terms"
     )
@@ -22,7 +22,7 @@ class Term(models.Model):
         choices=TERM_NUMBER.choices, help_text="Term number"
     )
 
-    # ~~~~ Optional ~~~~
+    # ~~~~~~~~ Optional ~~~~~~~~
     start_date = models.DateField(null=True, blank=True)
     end_date = models.DateField(null=True, blank=True)
 


### PR DESCRIPTION
## Summary
- order model attributes by relevance

## Testing
- `python3 -m black app/`
- `flake8 app/`
- `mypy app/` *(fails: Incompatible return value type errors)*
- `pytest -q` *(fails: OperationalError: no such table: shared_statushistory)*

------
https://chatgpt.com/codex/tasks/task_e_6861828f8c24832397ad70b778d7dea8