### PR TITLE
Add department relation to RoleAssignment

### DIFF
--- a/app/people/models/role_assignment.py
+++ b/app/people/models/role_assignment.py
@@ -19,6 +19,9 @@ class RoleAssignment(models.Model):
         ...     role=UserRole.REGISTRAR,
         ...     start_date=date.today(),
         ... )
+
+    The optional ``department`` field further scopes a role within a
+    specific academic department, similar to ``college``.
     """
 
     # ~~~~~~~~ Mandatory ~~~~~~~~
@@ -36,6 +39,13 @@ class RoleAssignment(models.Model):
         on_delete=models.SET_NULL,
         related_name="role_assignments",
     )
+    department = models.ForeignKey(
+        "academics.Department",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="role_assignments",
+    )
     end_date = models.DateField(null=True, blank=True)
 
     def __str__(self) -> str:
@@ -44,10 +54,10 @@ class RoleAssignment(models.Model):
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=["user", "role", "college", "start_date"],
+                fields=["user", "role", "college", "department", "start_date"],
                 name="unique_role_per_period",
             )
         ]
         indexes = [
-            models.Index(fields=["role", "college", "end_date"]),
+            models.Index(fields=["role", "college", "department", "end_date"]),
         ]

--- a/app/shared/auth/helpers.py
+++ b/app/shared/auth/helpers.py
@@ -51,6 +51,10 @@ def upsert_test_users_and_roles(
             user=user,
             role=role,
             college=college,
-            defaults={"start_date": timezone.now().date(), "end_date": None},
+            defaults={
+                "start_date": timezone.now().date(),
+                "end_date": None,
+                "department": None,
+            },
         )
         log(cmd, f"  ↳ {user.username} ({role})")

--- a/app/shared/auth/perms_helpers.py
+++ b/app/shared/auth/perms_helpers.py
@@ -35,7 +35,7 @@ def grant_model_level_perms(groups):
 
 def grant_college_object_perms():
     """Grant object-level college permissions to role assignments."""
-    for ra in RoleAssignment.objects.select_related("college"):
+    for ra in RoleAssignment.objects.select_related("college", "department"):
         if ra.college is None:
             continue
         for perm_name, roles in OBJECT_PERM_MATRIX["college"].items():

--- a/tests/people/test_role_assignment.py
+++ b/tests/people/test_role_assignment.py
@@ -11,13 +11,21 @@ from app.people.choices import UserRole
 pytestmark = pytest.mark.django_db
 
 
-def test_unique_role_per_period(user, college):
+def test_unique_role_per_period(user, college, department):
     start = date.today()
     RoleAssignment.objects.create(
-        user=user, role=UserRole.REGISTRAR, college=college, start_date=start
+        user=user,
+        role=UserRole.REGISTRAR,
+        college=college,
+        department=department,
+        start_date=start,
     )
     with pytest.raises(IntegrityError):
         with transaction.atomic():
             RoleAssignment.objects.create(
-                user=user, role=UserRole.REGISTRAR, college=college, start_date=start
+                user=user,
+                role=UserRole.REGISTRAR,
+                college=college,
+                department=department,
+                start_date=start,
             )


### PR DESCRIPTION
## Summary
- extend `RoleAssignment` with optional `department` FK
- handle new field in auth helpers
- update unique constraint and tests

## Testing
- `pytest tests/people/test_role_assignment.py::test_unique_role_per_period -q`

------
https://chatgpt.com/codex/tasks/task_e_686387dd1d8c8323992412ee2fd05137