### PR TITLE
Add reusable SemesterFilter

### DIFF
--- a/app/finance/admin/core.py
+++ b/app/finance/admin/core.py
@@ -2,6 +2,8 @@
 
 from django.contrib import admin
 
+from app.shared.admin import SemesterFilter
+
 from app.finance.models.payment import Payment
 
 from app.finance.models.payment_history import PaymentHistory
@@ -13,6 +15,7 @@ class PaymentAdmin(admin.ModelAdmin):
     """Admin settings for Payment."""
 
     list_display = ("__str__", "method", "recorded_by")
+    list_filter = (SemesterFilter,)
     readonly_fields = ("created_at",)
 
 
@@ -38,4 +41,5 @@ class PaymentHistoryAdmin(admin.ModelAdmin):
 
     # Shows summary string plus related info
     list_display = ("__str__", "financial_record", "method", "recorded_by")
+    list_filter = (SemesterFilter,)
     readonly_fields = ("payment_date",)

--- a/app/registry/admin/core.py
+++ b/app/registry/admin/core.py
@@ -5,6 +5,8 @@ from app.registry.models.registration import Registration
 from app.timetable.models.section import Section
 from django.contrib import admin
 
+from app.shared.admin import SemesterFilter
+
 from app.registry.models.class_roster import ClassRoster
 from app.registry.models.grade import Grade
 
@@ -33,6 +35,7 @@ class GradeAdmin(admin.ModelAdmin):
         "section__number",
     )
     autocomplete_fields = ("student", "section")
+    list_filter = (SemesterFilter,)
 
 
 @admin.register(ClassRoster)
@@ -44,6 +47,7 @@ class ClassRosterAdmin(admin.ModelAdmin):
     """
 
     list_display = ("section", "student_count", "last_updated")
+    list_filter = (SemesterFilter,)
     search_fields = (
         "section__course__code",
         "section__number",
@@ -62,6 +66,7 @@ class RegistrationAdmin(admin.ModelAdmin):
     """Allow students to register only for eligible sections."""
 
     list_display = ("student", "section", "status", "date_registered")
+    list_filter = (SemesterFilter,)
     autocomplete_fields = ("student", "section")
     search_fields = (
         "student__student_id",

--- a/app/shared/admin.py
+++ b/app/shared/admin.py
@@ -1,13 +1,49 @@
-"""tentative to move the filter by group up in the user admin interface."""
+"""Admin utilities for shared components."""
 
-# app/shared/admin.py
-# from django.contrib import admin
-# from django.contrib.auth.models import User
-# from django.contrib.auth.admin import UserAdmin as CoreUserAdmin
+from django.contrib import admin
+from django.utils import timezone
 
-# class UserAdmin(CoreUserAdmin):
-#     """Override the default UserAdmin to make the first filter be groups."""
-#     list_filter = ("groups", "is_staff", "is_superuser", "is_active")
+from app.timetable.models.semester import Semester
 
-# admin.site.unregister(User)
-# admin.site.register(User, UserAdmin)
+
+def get_current_semester() -> Semester | None:
+    """Return the semester covering today's date or the latest by start date."""
+    today = timezone.now().date()
+    sem = Semester.objects.filter(start_date__lte=today, end_date__gte=today).first()
+    if sem:
+        return sem
+    return Semester.objects.order_by("-start_date").first()
+
+
+class SemesterFilter(admin.SimpleListFilter):
+    """Filter queryset by semester with a current semester default."""
+
+    title = "semester"
+    parameter_name = "semester"
+
+    def lookups(self, request, model_admin):
+        semesters = Semester.objects.order_by("-start_date")
+        return [(s.id, str(s)) for s in semesters]
+
+    def queryset(self, request, qs):
+        semester_id = self.value()
+        if semester_id is None:
+            current = get_current_semester()
+            if not current:
+                return qs
+            semester_id = current.id
+        model = qs.model
+        field_names = {f.name for f in model._meta.get_fields()}
+        if "semester" in field_names:
+            return qs.filter(semester_id=semester_id)
+        if "section" in field_names:
+            return qs.filter(section__semester_id=semester_id)
+        if "program" in field_names:
+            return qs.filter(program__sections__semester_id=semester_id).distinct()
+        if "financial_record" in field_names:
+            return qs.filter(
+                financial_record__student__current_enroled_semester_id=semester_id
+            )
+        if "student" in field_names:
+            return qs.filter(student__current_enroled_semester_id=semester_id)
+        return qs


### PR DESCRIPTION
## Summary
- implement SemesterFilter with current-semester default
- filter registry and finance admin models by semester

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863883129b0832389273946f97653c3