### PR TITLE
Add permission tests using guardian

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,4 +13,5 @@ pytest_plugins = [
     "tests.finance.fixture",
     "tests.registry.fixture",
     "tests.shared.fixture",
+    "tests.shared.permissions_fixtures",
 ]

--- a/tests/shared/permissions_fixtures.py
+++ b/tests/shared/permissions_fixtures.py
@@ -1,0 +1,67 @@
+import datetime
+from typing import Callable
+
+import pytest
+from django.contrib.auth.models import Group, Permission, User
+from django.contrib.contenttypes.models import ContentType
+from guardian.shortcuts import assign_perm
+
+from app.academics.models.college import College
+from app.people.choices import UserRole
+from app.people.models.role_assignment import RoleAssignment
+
+
+def _group_name(role: UserRole) -> str:
+    """Return the default group name for a role."""
+
+    return " ".join(part.capitalize() for part in role.value.split("_"))
+
+
+@pytest.fixture
+def role_user_factory(college) -> Callable[[UserRole], User]:
+    """Return a callable creating a user, group, and role assignment."""
+
+    def _make(role: UserRole) -> User:
+        user = User.objects.create_user(username=f"{role.value}_user")
+        group, _ = Group.objects.get_or_create(name=_group_name(role))
+        ct = ContentType.objects.get_for_model(College)
+        perm = Permission.objects.get(codename="view_college", content_type=ct)
+        group.permissions.add(perm)
+        user.groups.add(group)
+        RoleAssignment.objects.create(
+            user=user,
+            role=role,
+            college=college,
+            start_date=datetime.date.today(),
+        )
+        assign_perm("view_college", user, college)
+        return user
+
+    return _make
+
+
+@pytest.fixture
+def dean_user(role_user_factory) -> User:
+    return role_user_factory(UserRole.DEAN)
+
+
+@pytest.fixture
+def chair_user(role_user_factory) -> User:
+    return role_user_factory(UserRole.CHAIR)
+
+
+@pytest.fixture
+def faculty_user(role_user_factory) -> User:
+    return role_user_factory(UserRole.FACULTY)
+
+
+@pytest.fixture
+def student_user(role_user_factory) -> User:
+    return role_user_factory(UserRole.STUDENT)
+
+
+@pytest.fixture
+def college_other(college_factory):
+    """Secondary college for permission checks."""
+
+    return college_factory(code="COBA")

--- a/tests/shared/test_permissions.py
+++ b/tests/shared/test_permissions.py
@@ -1,0 +1,42 @@
+"""Permission retrieval tests using django-guardian."""
+
+from guardian.shortcuts import get_objects_for_user
+import pytest
+
+from app.academics.models.college import College
+
+pytestmark = pytest.mark.django_db
+
+
+def _check_only_default_visible(user, college):
+    objs = get_objects_for_user(
+        user,
+        "academics.view_college",
+        College,
+        use_groups=False,
+        accept_global_perms=False,
+    )
+    assert list(objs) == [college]
+
+
+def _check_all_visible(user, college, college_other):
+    objs = get_objects_for_user(user, "academics.view_college", College)
+    assert set(objs) == {college, college_other}
+
+
+def test_object_level_access_restricted(
+    dean_user, chair_user, faculty_user, student_user, college, college_other
+):
+    """Users see only permitted object when using object-level perms."""
+
+    for user in (dean_user, chair_user, faculty_user, student_user):
+        _check_only_default_visible(user, college)
+
+
+def test_model_level_access(
+    dean_user, chair_user, faculty_user, student_user, college, college_other
+):
+    """Model-level permissions via groups return all objects."""
+
+    for user in (dean_user, chair_user, faculty_user, student_user):
+        _check_all_visible(user, college, college_other)


### PR DESCRIPTION
## Summary
- create fixtures for role-based users
- ensure django-guardian permissions work on colleges
- verify object and model level access

## Testing
- `codo-tuth-env/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686388637c048323acd6e201bcb57b0c