### PR TITLE
Add group assignment in import resources

### DIFF
--- a/app/people/admin/resources.py
+++ b/app/people/admin/resources.py
@@ -1,6 +1,8 @@
 """Resources module."""
 
 from import_export import fields, resources
+from django.contrib.auth.models import Group
+from app.people.choices import UserRole
 
 from app.people.admin.widgets import StaffProfileWidget, UserWidget
 from app.people.models.staffs import Faculty, Staff
@@ -68,6 +70,15 @@ class FacultyResource(resources.ModelResource):
         skip_unchanged = True
         report_skipped = False
 
+    def after_save_instance(self, instance, row, **kwargs) -> None:
+        """Assign the faculty group to the related user."""
+        if kwargs.get("dry_run"):
+            return
+
+        user = instance.staff_profile.user
+        group, _ = Group.objects.get_or_create(name=UserRole.FACULTY.label)
+        user.groups.add(group)
+
 
 class StudentResource(resources.ModelResource):
     """Resource for bulk importing Student rows."""
@@ -91,6 +102,14 @@ class StudentResource(resources.ModelResource):
             "current_enroled_semester",
             "first_enrollement_date",
         )
+
+    def after_save_instance(self, instance, row, **kwargs) -> None:
+        """Assign the student group to the user when importing."""
+        if kwargs.get("dry_run") or instance.user is None:
+            return
+
+        group, _ = Group.objects.get_or_create(name=UserRole.STUDENT.label)
+        instance.user.groups.add(group)
 
 
 class RegistrationResource(resources.ModelResource):

--- a/tests/people/test_import_groups.py
+++ b/tests/people/test_import_groups.py
@@ -1,0 +1,31 @@
+import pytest
+from tablib import Dataset
+from django.contrib.auth import get_user_model
+from app.people.admin.resources import StudentResource, FacultyResource
+from app.people.choices import UserRole
+from app.people.utils import mk_username
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_student_import_assigns_student_group(curriculum):
+    ds = Dataset()
+    ds.headers = ["student_id", "student_name", "curriculum"]
+    ds.append(["ST1", "Alice Example", curriculum.pk])
+    res = StudentResource().import_data(ds, dry_run=False)
+    assert not res.has_errors(), res.row_errors()
+    user = User.objects.get(username="alice.example")
+    assert user.groups.filter(name=UserRole.STUDENT.label).exists()
+
+
+@pytest.mark.django_db
+def test_faculty_import_assigns_faculty_group(college):
+    ds = Dataset()
+    ds.headers = ["faculty"]
+    ds.append(["Bob Example"])
+    res = FacultyResource().import_data(ds, dry_run=False)
+    assert not res.has_errors()
+    username = mk_username("Bob", "Example", unique=False)
+    user = User.objects.get(username=username)
+    assert user.groups.filter(name=UserRole.FACULTY.label).exists()


### PR DESCRIPTION
## Summary
- assign groups when importing students or faculty
- test that import assigns the proper group

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a91b80fac8323bc186c1d29feb8c6