### PR TITLE
Fix grade fixtures to use GradeType

### DIFF
--- a/app/people/models/student.py
+++ b/app/people/models/student.py
@@ -63,7 +63,8 @@ class Student(AbstractPerson):
         """Return courses the student completed with a passing grade."""
         return Course.objects.filter(
             in_programs__sections__grade__student=self,
-            in_programs__sections__grade__numeric_grade__gte=60,
+            # GradeType.number >= 1 == passing grade
+            in_programs__sections__grade__grade__number__gte=1,
         ).distinct()
 
     def allowed_courses(self) -> CourseQuery:

--- a/tests/people/test_student.py
+++ b/tests/people/test_student.py
@@ -7,7 +7,7 @@ from app.academics.models.department import Department
 from app.academics.models.prerequisite import Prerequisite
 from app.academics.models.program import Program
 from app.people.models.student import Student
-from app.registry.models.grade import Grade
+from app.registry.models.grade import Grade, GradeType
 from app.timetable.models.section import Section
 
 
@@ -39,9 +39,8 @@ def test_allowed_courses(student: Student, semester):
 
     assert course_a in allowed_initial
 
-    Grade.objects.create(
-        student=student, section=sec_a, letter_grade="A", numeric_grade=90
-    )
+    grade_type = GradeType.objects.create(code="A")
+    Grade.objects.create(student=student, section=sec_a, grade=grade_type)
 
     allowed = list(student.allowed_courses())
 

--- a/tests/registry/test_grade.py
+++ b/tests/registry/test_grade.py
@@ -1,6 +1,6 @@
 """Tests for registry grade model."""
 
-from app.registry.models.grade import Grade
+from app.registry.models.grade import Grade, GradeType
 import pytest
 from django.db import IntegrityError, transaction
 
@@ -12,11 +12,11 @@ pytestmark = pytest.mark.django_db  # replace the @pytest.mark.django_db decorat
 def test_grade_unique_student_section(student, section):
     """A student only have one grade for a section (the final grade)."""
 
-    Grade.objects.create(
-        student=student, section=section, letter_grade="A", numeric_grade=90
-    )
+    grade_a = GradeType.objects.create(code="A")
+    grade_b = GradeType.objects.create(code="B")
+    Grade.objects.create(student=student, section=section, grade=grade_a)
     with pytest.raises(IntegrityError):
         with transaction.atomic():
             Grade.objects.create(
-                student=student, section=section, letter_grade="B", numeric_grade=80
+                student=student, section=section, grade=grade_b
             )

--- a/tests/shared/_test_historical_access.py
+++ b/tests/shared/_test_historical_access.py
@@ -11,7 +11,7 @@ from app.finance.admin.core import FinancialRecordAdmin, PaymentHistoryAdmin
 from app.finance.models import FinancialRecord, PaymentHistory
 from app.people.models.student import Student
 from app.registry.admin.core import GradeAdmin, RegistrationAdmin
-from app.registry.models import Grade, Registration
+from app.registry.models import Grade, GradeType, Registration
 from app.timetable.models.section import Section
 from app.academics.models.program import Program
 
@@ -45,12 +45,10 @@ def setup_records(
         current_enroled_semester=past_sem,
     )
 
-    Grade.objects.create(
-        student=stud_current, section=sec_current, letter_grade="A", numeric_grade=90
-    )
-    Grade.objects.create(
-        student=stud_past, section=sec_past, letter_grade="B", numeric_grade=80
-    )
+    grade_a = GradeType.objects.create(code="A")
+    grade_b = GradeType.objects.create(code="B")
+    Grade.objects.create(student=stud_current, section=sec_current, grade=grade_a)
+    Grade.objects.create(student=stud_past, section=sec_past, grade=grade_b)
 
     Registration.objects.create(student=stud_current, section=sec_current)
     Registration.objects.create(student=stud_past, section=sec_past)


### PR DESCRIPTION
## Summary
- update grade fixtures to create GradeType
- adjust student grade queries for GradeType
- update grade tests and related fixtures

## Testing
- `codo-tuth-env/bin/python -m pytest -q` *(fails: tests/test_model_crud.py::test_crud_every_model[GradeType], tests/academics/test_concentration.py::test_major_get_default_has_program, tests/academics/test_concentration.py::test_minor_get_default_has_program, tests/academics/test_concentration.py::test_major_clean_requires_program, tests/people/test_import_groups.py::test_student_import_assigns_student_group, tests/academics/test_concentration.py::test_total_credit_hours_sums_programs, tests/academics/test_concentration.py::test_major_clean_credit_limit_exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_687c201289c483239816e11f99f54d52