### PR TITLE
Add create_student view and tests

### DIFF
--- a/app/website/templates/website/create_student.html
+++ b/app/website/templates/website/create_student.html
@@ -1,0 +1,24 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Create Student</title>
+    <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet" />
+  </head>
+  <body class="p-4">
+    <h1 class="mb-4">Create Student</h1>
+    {% if messages %}
+    <div class="mb-3">
+      {% for message in messages %}
+        <div class="alert alert-info">{{ message }}</div>
+      {% endfor %}
+    </div>
+    {% endif %}
+    <form method="post">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+  </body>
+</html>

--- a/app/website/urls.py
+++ b/app/website/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     # “admin:login” is provided by Django’s admin site
     path("", TemplateView.as_view(template_name="website/landing.html"), name="landing"),
     path("courses/", views.course_dashboard, name="course_dashboard"),
+    path("students/new/", views.create_student, name="create_student"),
 ]

--- a/app/website/views.py
+++ b/app/website/views.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import cast
 
 from django.contrib import messages
+from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import PermissionDenied
 from django.db import connection
@@ -16,6 +17,7 @@ from app.registry.choices import StatusRegistration
 from app.registry.models.registration import Registration
 from app.shared.status import StatusHistory
 from app.timetable.models.section import Section
+from app.people.forms.person import StudentForm
 
 
 def landing_page(request: HttpRequest) -> HttpResponse:
@@ -83,3 +85,19 @@ def course_dashboard(request: HttpRequest) -> HttpResponse:
     }
 
     return render(request, "website/course_dashboard.html", context)
+
+
+@permission_required("people.add_student", raise_exception=True)
+def create_student(request: HttpRequest) -> HttpResponse:
+    """Allow enrollment officers to create a new student profile."""
+
+    if request.method == "POST":
+        form = StudentForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Student created successfully.")
+            return redirect("create_student")
+    else:
+        form = StudentForm()
+
+    return render(request, "website/create_student.html", {"form": form})

--- a/tests/website/test_create_student.py
+++ b/tests/website/test_create_student.py
@@ -1,0 +1,43 @@
+"""Tests for the create_student view."""
+
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import Permission, ContentType
+
+from app.people.choices import UserRole
+from app.people.models.student import Student
+
+
+@pytest.mark.django_db
+def test_enrollment_officer_can_create_student(client, role_user_factory, curriculum, semester):
+    """Enrollment officers can access the form and create a student."""
+    officer = role_user_factory(UserRole.ENROLLMENT_OFFICER)
+    ct = ContentType.objects.get_for_model(Student)
+    perm = Permission.objects.get(codename="add_student", content_type=ct)
+    officer.groups.first().permissions.add(perm)
+
+    client.force_login(officer)
+    url = reverse("create_student")
+
+    response = client.get(url)
+    assert response.status_code == 200
+
+    data = {
+        "first_name": "Alice",
+        "last_name": "Smith",
+        "curriculum": curriculum.id,
+        "current_enroled_semester": semester.id,
+    }
+
+    response = client.post(url, data)
+    assert response.status_code == 302
+    assert Student.objects.filter(user__first_name="Alice", user__last_name="Smith").exists()
+
+
+@pytest.mark.django_db
+def test_unauthorized_user_gets_403(client, user, curriculum):
+    """Unauthorized users are forbidden."""
+    client.force_login(user)
+    url = reverse("create_student")
+    response = client.get(url)
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- add `create_student` view with permission check
- add template to render student creation form
- expose view via new URL pattern
- test enrollment officer access and unauthorized access

## Testing
- `pytest -q` *(fails: KeyError 'IP_upd', AttributeError 'Major' object has no attribute 'programs', NameError 'Group' is not defined, ...)*

------
https://chatgpt.com/codex/tasks/task_e_687cd685c1ac8323a4cea96205e1ef57