### PR TITLE
Add semester support to registration test factory

### DIFF
--- a/tests/registry/fixture.py
+++ b/tests/registry/fixture.py
@@ -13,7 +13,7 @@ from app.registry.choices import DocumentType, StatusRegistration
 from app.registry.models import Document, Grade, Registration
 from app.registry.models.grade import GradeValue
 
-RegistrationFactory: TypeAlias = Callable[[str, str, str, str], Registration]
+RegistrationFactory: TypeAlias = Callable[[str, str, str, str, int], Registration]
 GradeFactory: TypeAlias = Callable[[str, str, str, str, Decimal], Grade]
 DocumentFactory: TypeAlias = Callable[[str, str], Document]
 
@@ -62,18 +62,20 @@ def document(student_factory) -> Document:
 
 @pytest.fixture
 def registration_factory(student_factory, section_factory) -> RegistrationFactory:
-    """Return a callable to build registrations."""
+    """Return a callable to build registrations.
 
-    #    TODO
+    Parameters allow customizing the semester of the created section.
+    """
     def _make(
         student_uname: str,
         curri_short_name: str,
         course_number: str,
         status: str = StatusRegistration.PENDING,
+        semester_number: int = 1,
     ) -> Registration:
         return Registration.objects.create(
             student=student_factory(student_uname, curri_short_name),
-            section=section_factory(course_number, curri_short_name),
+            section=section_factory(course_number, curri_short_name, 1, semester_number),
             status=status,
         )
 

--- a/tests/timetable/fixture.py
+++ b/tests/timetable/fixture.py
@@ -16,7 +16,7 @@ from tests.academics.fixture import ProgramFactory
 
 AcademicYearFactory: TypeAlias = Callable[[datetime], AcademicYear]
 SemesterFactory: TypeAlias = Callable[[int], Semester]
-SectionFactory: TypeAlias = Callable[[str, str, int], Section]
+SectionFactory: TypeAlias = Callable[[str, str, int, int], Section]
 SecSessionFactory: TypeAlias = Callable[[str, str, str], SecSession]
 
 DEF_DATE = datetime(2010, 9, 1)
@@ -84,8 +84,9 @@ def section_factory(
         course_number: str = "111",
         curriculum_short_name: str = "CURRI_TEST",
         number: int = 1,
+        semester_number: int = 1,
     ) -> Section:
-        semester = semester_factory(1)
+        semester = semester_factory(semester_number)
         program = program_factory(course_number, curriculum_short_name)
         return Section.objects.create(program=program, semester=semester, number=number)
 


### PR DESCRIPTION
## Summary
- enhance timetable section factory with optional semester argument
- extend registration factory so semester can be specified

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `pip install --break-system-packages -q -r requirements-test.txt` *(fails to build pygraphviz)*

------
https://chatgpt.com/codex/tasks/task_e_687d24b53fe0832391cf05c8fbd278d2