### PR TITLE
feat(academics): compute student credits for class levels

### DIFF
--- a/app/academics/admin/core.py
+++ b/app/academics/admin/core.py
@@ -43,7 +43,15 @@ class CollegeAdmin(SimpleHistoryAdmin, ImportExportModelAdmin, GuardedModelAdmin
     """
 
     resource_class = CollegeResource
-    list_display = ("code", "long_name")
+    list_display = (
+        "code",
+        "long_name",
+        "faculty_count",
+        "course_count",
+        "curricula_names",
+        "department_chairs",
+        "student_counts_by_level",
+    )
     search_fields = ("code", "long_name")
 
 

--- a/app/academics/models/college.py
+++ b/app/academics/models/college.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from django.db import models
 from simple_history.models import HistoricalRecords
 
-from app.academics.choices import CollegeCodeChoices, CollegeLongNameChoices
+from app.academics.choices import (
+    CollegeCodeChoices,
+    CollegeLongNameChoices,
+    LEVEL_NUMBER,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - avoid circular imports at runtime
+    from app.academics.models import Course, Curriculum, Department
+    from app.people.models.student import Student
+    from app.people.models.staffs import Faculty
+    from app.people.models.role_assignment import RoleAssignment
 
 
 class College(models.Model):
@@ -58,6 +70,70 @@ class College(models.Model):
         """Ensure long_name matches the selected code before saving."""
         self._ensure_long_name()
         super().save(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # computed properties
+    # ------------------------------------------------------------------
+
+    @property
+    def student_counts_by_level(self) -> str:
+        """Return number of students grouped by class level."""
+        from app.people.models.student import Student
+
+        counts = {lv.label: 0 for lv in LEVEL_NUMBER}
+        for stud in Student.objects.filter(curriculum__college=self):
+            credits = stud.completed_credits
+            if credits <= 36:
+                level = LEVEL_NUMBER.ONE.label
+            elif credits <= 72:
+                level = LEVEL_NUMBER.TWO.label
+            elif credits <= 108:
+                level = LEVEL_NUMBER.THREE.label
+            else:
+                level = LEVEL_NUMBER.FOUR.label
+            counts[level] += 1
+        return ", ".join(f"{lvl}: {cnt}" for lvl, cnt in counts.items())
+
+    @property
+    def department_chairs(self) -> str:
+        """Return departments with their current chair names."""
+        from app.people.choices import UserRole
+        from app.people.models.role_assignment import RoleAssignment
+
+        result: list[str] = []
+        for dept in self.departments.all():
+            chair = (
+                RoleAssignment.objects.filter(
+                    department=dept,
+                    role=UserRole.CHAIR,
+                    end_date__isnull=True,
+                )
+                .select_related("user")
+                .first()
+            )
+            chair_name = chair.user.get_full_name() if chair else ""
+            result.append(f"{dept.short_name}: {chair_name}")
+        return ", ".join(result)
+
+    @property
+    def curricula_names(self) -> str:
+        """Return curriculum short names for this college."""
+        names = self.curricula.values_list("short_name", flat=True)
+        return ", ".join(names)
+
+    @property
+    def faculty_count(self) -> int:
+        """Return number of faculty members in the college."""
+        from app.people.models.staffs import Faculty
+
+        return Faculty.objects.filter(college=self).count()
+
+    @property
+    def course_count(self) -> int:
+        """Return number of distinct courses offered."""
+        from app.academics.models.course import Course
+
+        return Course.objects.filter(department__college=self).distinct().count()
 
     class Meta:
         constraints = [

--- a/app/people/models/student.py
+++ b/app/people/models/student.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from app.people.choices import UserRole
 from django.db import models
 
+from app.academics.choices import LEVEL_NUMBER
 from app.academics.models.course import Course
 from app.academics.models.curriculum import Curriculum
 from app.people.models.core import AbstractPerson
@@ -68,6 +69,30 @@ class Student(AbstractPerson):
             # GradeType.number >= 1 == passing grade
             in_programs__sections__grade__value__number__gte=1,
         ).distinct()
+
+    @property
+    def completed_credits(self) -> int:
+        """Return sum of credit hours successfully completed."""
+        from django.db.models import Sum
+        from app.academics.models.program import Program
+
+        passed_ids = self.passed_courses().values_list("id", flat=True)
+        agg = Program.objects.filter(
+            curriculum=self.curriculum, course_id__in=passed_ids
+        ).aggregate(total=Sum("credit_hours"))
+        return agg.get("total") or 0
+
+    @property
+    def class_level(self) -> str:
+        """Return student level computed from completed credits."""
+        credits = self.completed_credits
+        if credits <= 36:
+            return LEVEL_NUMBER.ONE.label
+        if credits <= 72:
+            return LEVEL_NUMBER.TWO.label
+        if credits <= 108:
+            return LEVEL_NUMBER.THREE.label
+        return LEVEL_NUMBER.FOUR.label
 
     def allowed_courses(self) -> CourseQuery:
         """Return courses available for registration based on prerequisites."""

--- a/tests/academics/test_college.py
+++ b/tests/academics/test_college.py
@@ -1,1 +1,74 @@
-"""Tests for the academic college model."""
+"""Tests for the academic :class:`College` model."""
+
+from datetime import date
+
+import pytest
+from django.contrib.auth.models import User
+
+from app.academics.models.college import College
+from app.academics.models.curriculum import Curriculum
+from app.academics.models.department import Department
+from app.academics.models.course import Course
+from app.academics.models.program import Program
+from app.registry.models.grade import Grade, GradeValue
+from app.timetable.models.academic_year import AcademicYear
+from app.timetable.models.semester import Semester
+from app.timetable.models.section import Section
+from app.academics.choices import CREDIT_NUMBER
+from app.people.models.staffs import Staff, Faculty
+from app.people.models.student import Student
+from app.people.models.role_assignment import RoleAssignment
+from app.people.choices import UserRole
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_college_computed_fields():
+    """College properties return expected aggregate information."""
+
+    college = College.objects.create(code="COAS")
+    dept = Department.objects.create(short_name="SCI", college=college)
+    curr1 = Curriculum.objects.create(short_name="CUR1", college=college)
+    Curriculum.objects.create(short_name="CUR2", college=college)
+    courses = [
+        Course.objects.create(department=dept, number=n)
+        for n in ["101", "102", "201", "202"]
+    ]
+    programs = [
+        Program.objects.create(
+            course=c, curriculum=curr1, credit_hours=CREDIT_NUMBER.TEN
+        )
+        for c in courses
+    ]
+    year = AcademicYear.objects.create(start_date=date(2024, 9, 1))
+    sem = Semester.objects.create(academic_year=year, number=1)
+    sections = [
+        Section.objects.create(program=p, semester=sem, number=1)
+        for p in programs
+    ]
+
+    staff = Staff.objects.create(user=User.objects.create(username="fac"))
+    Faculty.objects.create(staff_profile=staff, college=college)
+
+    chair_user = User.objects.create(username="chair", first_name="C", last_name="H")
+    RoleAssignment.objects.create(
+        user=chair_user,
+        role=UserRole.CHAIR,
+        college=college,
+        department=dept,
+        start_date=date.today(),
+    )
+
+    student = Student.objects.create(
+        user=User.objects.create(username="stud"), curriculum=curr1
+    )
+    grade_value = GradeValue.objects.create(code="A")
+    for sec in sections:
+        Grade.objects.create(student=student, section=sec, value=grade_value)
+
+    assert college.faculty_count == 1
+    assert college.course_count == 4
+    assert "CUR1" in college.curricula_names
+    assert "SCI" in college.department_chairs
+    assert "sophomore: 1" in college.student_counts_by_level


### PR DESCRIPTION
## Summary
- calculate student level using completed credit hours
- expose level distribution via College property
- update college tests for credit-based levels

## Testing
- `DJANGO_SETTINGS_MODULE=app.settings python3 -m pytest tests/academics/test_college.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d24d6c0a4832386df498385184f12