### PR TITLE
feat: support role model expansion in permission matrix

### DIFF
--- a/app/shared/management/commands/create_test_users.py
+++ b/app/shared/management/commands/create_test_users.py
@@ -10,7 +10,7 @@ from django.core.management.base import BaseCommand
 from app.people.models.role_assignment import RoleAssignment
 from app.people.models.staffs import Faculty
 from app.shared.auth.helpers import ensure_superuser
-from app.shared.auth.perms import APP_MODELS, TEST_PW, UserRole
+from app.shared.auth.perms import APP_MODELS, TEST_PW, UserRole, expand_role_model
 
 
 class Command(BaseCommand):
@@ -76,7 +76,7 @@ def sync_role_group(role_code: str, rights: dict[str, list[str]]) -> Group:
     perms = []
 
     for action, models in rights.items():
-        for model in models:
+        for model in expand_role_model(models):
             app_label = get_app_label(model)
             model_cls = apps.get_model(app_label, model)
             ct = ContentType.objects.get_for_model(model_cls)

--- a/app/shared/management/commands/load_roles.py
+++ b/app/shared/management/commands/load_roles.py
@@ -15,6 +15,7 @@ from django.core.management.base import BaseCommand
 from app.shared.auth.perms import (
     APP_MODELS,
     ROLE_MATRIX,
+    expand_role_model,
 )
 
 
@@ -52,7 +53,7 @@ def sync_role_group(role_code: str, rights: dict[str, list[str]]) -> Group:
     perms = []
 
     for action, models in rights.items():
-        for model in models:
+        for model in expand_role_model(models):
             app_label = get_app_label(model)
             model_cls = apps.get_model(app_label, model)
             ct = ContentType.objects.get_for_model(model_cls)

--- a/tests/shared/test_expand_role_model.py
+++ b/tests/shared/test_expand_role_model.py
@@ -1,0 +1,29 @@
+import pytest
+
+from app.shared.auth.perms import APP_MODELS, expand_role_model
+
+
+def test_expand_role_model_app_expansion():
+    models = ["Academics"]
+    result = expand_role_model(models)
+    assert result == APP_MODELS["academics"]
+
+
+def test_expand_role_model_with_exclusions():
+    models = ["Academics-college-department"]
+    expected = [m for m in APP_MODELS["academics"] if m not in {"college", "department"}]
+    result = expand_role_model(models)
+    assert result == expected
+
+
+def test_expand_role_model_exclusion_limit():
+    models = ["Academics-college-department-course"]
+    with pytest.raises(ValueError):
+        expand_role_model(models)
+
+
+def test_expand_role_model_mixed_tokens():
+    models = ["student", "Academics-college"]
+    expected = ["student"] + [m for m in APP_MODELS["academics"] if m != "college"]
+    result = expand_role_model(models)
+    assert result == expected


### PR DESCRIPTION
## Summary
- expand ROLE_MATRIX model tokens with new `expand_role_model` helper
- apply expansion when syncing role permissions
- test expansion, exclusions and limits

## Testing
- `pip install -r requirements-test.txt` *(fails: pygraphviz missing graphviz/cgraph.h)*
- `pytest tests/shared/test_expand_role_model.py -q -p no:tests.timetable.fixture -p no:tests.academics.fixture -p no:tests.people.fixture -p no:tests.spaces.fixture -p no:tests.finance.fixture -p no:tests.registry.fixture -p no:tests.shared.fixture -p no:tests.shared.permissions_fixtures`


------
https://chatgpt.com/codex/tasks/task_e_689604f2f51c8323b440682e59ac0a92