### PR TITLE
feat: show group members on admin detail

### DIFF
--- a/app/shared/admin/__init__.py
+++ b/app/shared/admin/__init__.py
@@ -2,9 +2,12 @@
 
 from app.shared.admin.core import get_current_semester
 from app.shared.admin.mixins import CollegeRestrictedAdmin, DepartmentRestrictedAdmin
+# register customized Group admin
+from app.shared.admin.group import GroupAdmin
 
 __all__ = [
     "get_current_semester",
     "CollegeRestrictedAdmin",
     "DepartmentRestrictedAdmin",
+    "GroupAdmin",
 ]

--- a/app/shared/admin/group.py
+++ b/app/shared/admin/group.py
@@ -1,0 +1,22 @@
+"""Admin customization for Group model."""
+
+from django.contrib import admin
+from django.contrib.auth.admin import GroupAdmin as DjangoGroupAdmin
+from django.contrib.auth.models import Group
+
+
+class GroupAdmin(DjangoGroupAdmin):
+    """Show group members in the admin detail view."""
+
+    # List the users belonging to the group
+    readonly_fields = ("user_list",)
+    fields = ("name", "permissions", "user_list")
+
+    def user_list(self, obj: Group) -> str:
+        """Return a comma-separated list of usernames."""
+        return ", ".join(user.username for user in obj.user_set.all())
+
+
+# Replace the default admin with the customized one
+admin.site.unregister(Group)
+admin.site.register(Group, GroupAdmin)

--- a/tests/shared/test_group_admin_users.py
+++ b/tests/shared/test_group_admin_users.py
@@ -1,0 +1,19 @@
+"""Tests for the Group admin customization."""
+
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_group_admin_shows_users(client, superuser, user_factory, group_factory):
+    """Group change page should display member usernames."""
+    group = group_factory("Editors")
+    user = user_factory("alice")
+    group.user_set.add(user)
+
+    client.force_login(superuser)
+    url = reverse("admin:auth_group_change", args=[group.id])
+    res = client.get(url)
+    assert res.status_code == 200
+    assert "alice" in res.content.decode()


### PR DESCRIPTION
## Summary
- display users belonging to a group on the group admin page
- cover group admin user listing with test

## Testing
- `python3 -m pytest tests/shared/test_group_admin_users.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a026b59b1083239a92f243e300de88